### PR TITLE
Fix w(t)

### DIFF
--- a/nerf/sd.py
+++ b/nerf/sd.py
@@ -94,7 +94,7 @@ class StableDiffusion(nn.Module):
         noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
         # w(t), one_minus_alpha_prod, i.e., sigma^2
-        w = (1 - self.scheduler.alphas_cumprod[t]).to(self.device)
+        w = torch.sqrt(self.scheduler.alphas_cumprod[t]).to(self.device)
         grad = w * (noise_pred - noise)
 
         # clip grad for stable training?


### PR DESCRIPTION
In the paper, w(t) is given as dz_t/x. 
z_t = sqrt(alpha_t)  * x + sqrt(1 - alpha_t) * noise
=> d z_t / dx = sqrt(alpha_t)

But in L97 (linked below), (1 - alpha_t) is written instead of sqrt(alpha_t):
https://github.com/ashawkey/stable-dreamfusion/blob/0cb8c0e0fdf8944cbb431983f08deb082a2e3f56/nerf/sd.py#L97

Is my understanding incorrect? Or does w(t) need to be fixed as in this PR?
https://github.com/voletiv/stable-dreamfusion/blob/612dd4f304d334f1d0df70627decd2750c54bf2f/nerf/sd.py#L97
