### PR TITLE
missing requirements for MacOS setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 torch-ema
 ninja
+cmake
+setuptools_rust
 trimesh
 opencv-python
 tensorboardX


### PR DESCRIPTION
When installing the requirements, there were two packages missing to pass `pip install -r requirements.txt` causing `Module not Found` error on MacOS 12.6 device.