### PR TITLE
Check for cl.exe in 64bit Program Files on Windows

### DIFF
--- a/raymarching/backend.py
+++ b/raymarching/backend.py
@@ -16,10 +16,11 @@ elif os.name == "nt":
     # find cl.exe
     def find_cl_path():
         import glob
-        for edition in ["Enterprise", "Professional", "BuildTools", "Community"]:
-            paths = sorted(glob.glob(r"C:\\Program Files (x86)\\Microsoft Visual Studio\\*\\%s\\VC\\Tools\\MSVC\\*\\bin\\Hostx64\\x64" % edition), reverse=True)
-            if paths:
-                return paths[0]
+        for program_bit in ["", " (x86)"]:
+            for edition in ["Enterprise", "Professional", "BuildTools", "Community"]:
+                paths = sorted(glob.glob(r"C:\\Program Files%s\\Microsoft Visual Studio\\*\\%s\\VC\\Tools\\MSVC\\*\\bin\\Hostx64\\x64" % (program_bit, edition)), reverse=True)
+                if paths:
+                    return paths[0]
 
     # If cl.exe is not on path, try to find it.
     if os.system("where cl.exe >nul 2>nul") != 0:


### PR DESCRIPTION
`Program Files (x86)` is used for 32bit programs on Windows, 64bit apps are stored in `Program Files`
This change makes it so that the search for the VS Build tools considers the 64bit path as well.