### PR TITLE
option to make training more deterministic

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -20,6 +20,7 @@ parser.add_argument('--eval_interval', type=int, default=10, help="evaluate on t
 parser.add_argument('--workspace', type=str, default='trial_gradio')
 parser.add_argument('--guidance', type=str, default='stable-diffusion', help='choose from [stable-diffusion, clip]')
 parser.add_argument('--seed', type=int, default=0)
+parser.add_argument('--deterministic', action='store_true', help="make the training deterministic, but slower")
 
 parser.add_argument('--save_mesh', action='store_true', help="export an obj mesh with texture")
 parser.add_argument('--mcubes_resolution', type=int, default=256, help="mcubes resolution for extracting mesh")
@@ -39,7 +40,7 @@ parser.add_argument('--albedo_iters', type=int, default=1000, help="training ite
 parser.add_argument('--uniform_sphere_rate', type=float, default=0.5, help="likelihood of sampling camera location uniformly on the sphere surface area")
 # model options
 parser.add_argument('--bg_radius', type=float, default=1.4, help="if positive, use a background model at sphere(bg_radius)")
-parser.add_argument('--density_activation', type=str, default='softplus', choices=['softplus', 'exp'] help="density activation function")
+parser.add_argument('--density_activation', type=str, default='softplus', choices=['softplus', 'exp'], help="density activation function")
 parser.add_argument('--density_thresh', type=float, default=10, help="threshold for density grid to be occupied")
 parser.add_argument('--blob_density', type=float, default=10, help="max (center) density for the density blob")
 parser.add_argument('--blob_radius', type=float, default=0.3, help="control the radius for the density blob")
@@ -106,7 +107,7 @@ print(f'[INFO] loading models..')
 
 if opt.guidance == 'stable-diffusion':
     from nerf.sd import StableDiffusion
-    guidance = StableDiffusion(device, opt.sd_version, opt.hf_key)
+    guidance = StableDiffusion(opt, device, opt.sd_version, opt.hf_key)
 elif opt.guidance == 'clip':
     from nerf.clip import CLIP
     guidance = CLIP(device)

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     parser.add_argument('--workspace', type=str, default='workspace')
     parser.add_argument('--guidance', type=str, default='stable-diffusion', help='choose from [stable-diffusion, clip]')
     parser.add_argument('--seed', type=int, default=0)
+    parser.add_argument('--deterministic', action='store_true', help="make the training more deterministic, but slower")
 
     parser.add_argument('--save_mesh', action='store_true', help="export an obj mesh with texture")
     parser.add_argument('--mcubes_resolution', type=int, default=256, help="mcubes resolution for extracting mesh")
@@ -111,7 +112,7 @@ if __name__ == '__main__':
 
     print(opt)
 
-    seed_everything(opt.seed)
+    seed_everything(opt.seed, deterministic = opt.deterministic)
 
     model = NeRFNetwork(opt)
 
@@ -160,7 +161,7 @@ if __name__ == '__main__':
 
         if opt.guidance == 'stable-diffusion':
             from nerf.sd import StableDiffusion
-            guidance = StableDiffusion(device, opt.sd_version, opt.hf_key)
+            guidance = StableDiffusion(opt, device, opt.sd_version, opt.hf_key)
         elif opt.guidance == 'clip':
             from nerf.clip import CLIP
             guidance = CLIP(device)

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -105,14 +105,17 @@ def get_rays(poses, intrinsics, H, W, N=-1, error_map=None):
     return results
 
 
-def seed_everything(seed):
+def seed_everything(seed, deterministic=False):
     random.seed(seed)
     os.environ['PYTHONHASHSEED'] = str(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
-    #torch.backends.cudnn.deterministic = True
-    #torch.backends.cudnn.benchmark = True
+    if deterministic:
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ":4096:8" # https://discuss.pytorch.org/t/random-seed-with-external-gpu/102260/3 https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False # https://pytorch.org/docs/stable/notes/randomness.html#cuda-convolution-benchmarking
+        torch.use_deterministic_algorithms(True) # will raise error when nondeterministic functions are used.
 
 
 def torch_vis_2d(x, renormalize=False):


### PR DESCRIPTION
#114 #140 



I have been trying to make it more deterministic, here I share some of my experiences.

1. replace [these lines](https://github.com/ashawkey/stable-dreamfusion/blob/main/nerf/utils.py#L115) with 
```python
torch.backends.cudnn.deterministic = True
torch.backends.cudnn.benchmark = False # this should be False instead of True(current code)
torch.use_deterministic_algorithms(True) # will raise an error when nondeterministic functions are used.
```
check https://pytorch.org/docs/stable/notes/randomness.html#cuda-convolution-benchmarking for more details

2. you may need to run the program with flag `CUBLAS_WORKSPACE_CONFIG=:4096:8`, if some error is raised after doing 1, check [here](https://discuss.pytorch.org/t/random-seed-with-external-gpu/102260/3) for details

3. replace the bilinear `F.interpolate` [here](https://github.com/ashawkey/stable-dreamfusion/blob/fced54bf9452639de1fcb61e891e3c8233ab38e0/nerf/sd.py#L98) with the implementation below, as it is nondeterministic, check [here](https://github.com/open-mmlab/mmsegmentation/issues/255) fore details.
```python
class Interpolate(nn.Module):

    def __init__(self, channel: int, scale_factor: int):
        super().__init__()
        # assert 'mode' not in kwargs and 'align_corners' not in kwargs and 'size' not in kwargs
        assert isinstance(scale_factor, int) and scale_factor > 1 and scale_factor % 2 == 0
        self.scale_factor = scale_factor
        kernel_size = scale_factor + 1  # keep kernel size being odd
        self.weight = nn.Parameter(
            torch.empty((1, 1, kernel_size, kernel_size), dtype=torch.float32).expand(channel, -1, -1, -1)
        )
        self.conv = functools.partial(
            F.conv2d, weight=self.weight, bias=None, padding=scale_factor // 2, groups=channel
        )
        with torch.no_grad():
            self.weight.fill_(1 / (kernel_size * kernel_size))

    def forward(self, t):
        if t is None:
            return t
        return self.conv(F.interpolate(t, scale_factor=self.scale_factor, mode='nearest'))

    @staticmethod
    def naive(t: torch.Tensor, size: Tuple[int, int], **kwargs):
        if t is None or t.shape[2:] == size:
            return t
        else:
            assert 'mode' not in kwargs and 'align_corners' not in kwargs
            return F.interpolate(t, size, mode='nearest', **kwargs)
```

### However, the training is still non-deterministic

As the raymarching_train [here](https://github.com/ashawkey/stable-dreamfusion/blob/fced54bf9452639de1fcb61e891e3c8233ab38e0/nerf/renderer.py#L500) is non-deterministic, I am not familiar with CUDA extension, thus I don't know how to solve it, you might want to look at it, the `rays` outputted by the function is non-deterministic. 

Here I provide a bash script `test.sh` to run deterministic experiments for  debugging

```bash
gpu_id=$1
echo "Running on GPU $gpu_id"
rm -rf "results/squirrel_seed0_size64_deterministic_run$gpu_id"
rm deterministic_run_$gpu_id.txt

CUDA_LAUNCH_BLOCKING=1 CUDA_VISIBLE_DEVICES=$gpu_id python main.py \
--text "A DSLR photo of a squirrel" \
--cuda_ray \
--fp16 \
--dir_text \
--sd_version "2.0" \
--eval_interval 1 \
--seed 0 \
--iters 20 \
--workspace "results/squirrel_seed0_size64_deterministic_run$gpu_id" > deterministic_run_$gpu_id.txt 
```

run `bash test.sh 0` and `bash test.sh 1` to run on GPU 0 and GPU 1, and compare the output in `deterministic_run_0.txt `,`deterministic_run_1.txt `,

