### PR TITLE
adding images to tensorboard and add --name to compare data in tensorboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     parser.add_argument('--workspace', type=str, default='workspace')
     parser.add_argument('--guidance', type=str, default='stable-diffusion', help='choose from [stable-diffusion, clip]')
     parser.add_argument('--seed', type=int, default=0)
+    parser.add_argument('--name', type=str, default='df')
 
     parser.add_argument('--save_mesh', action='store_true', help="export an obj mesh with texture")
     parser.add_argument('--mcubes_resolution', type=int, default=256, help="mcubes resolution for extracting mesh")
@@ -122,7 +123,7 @@ if __name__ == '__main__':
     if opt.test:
         guidance = None # no need to load guidance model at test
 
-        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, fp16=opt.fp16, use_checkpoint=opt.ckpt)
+        trainer = Trainer(' '.join(sys.argv), opt.name, opt, model, guidance, device=device, workspace=opt.workspace, fp16=opt.fp16, use_checkpoint=opt.ckpt)
 
         if opt.gui:
             gui = NeRFGUI(opt, trainer)
@@ -167,7 +168,7 @@ if __name__ == '__main__':
         else:
             raise NotImplementedError(f'--guidance {opt.guidance} is not implemented.')
 
-        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=None, fp16=opt.fp16, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
+        trainer = Trainer(' '.join(sys.argv), opt.name, opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=None, fp16=opt.fp16, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
 
         if opt.gui:
             trainer.train_loader = train_loader # attach dataloader to trainer

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -849,8 +849,10 @@ class Trainer(object):
                 if self.local_rank == 0:
 
                     # save image
-                    save_path = os.path.join(self.workspace, 'validation', f'{name}_{self.local_step:04d}_rgb.png')
-                    save_path_depth = os.path.join(self.workspace, 'validation', f'{name}_{self.local_step:04d}_depth.png')
+                    save_path = os.path.join(self.workspace, f'{self.name}')
+                    save_path = os.path.join(save_path, 'validation', f'{name}_{self.local_step:04d}_rgb.png')
+                    save_path_depth = os.path.join(self.workspace, f'{self.name}')
+                    save_path_depth = os.path.join(save_path_depth, 'validation', f'{name}_{self.local_step:04d}_depth.png')
 
                     #self.log(f"==> Saving validation image to {save_path}")
                     os.makedirs(os.path.dirname(save_path), exist_ok=True)

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -866,8 +866,8 @@ class Trainer(object):
                         t_pred_depth = torch.from_numpy(pred_depth).unsqueeze(0)
                     
                         #add as image
-                        self.writer.add_image(f'{self.name}_{self.local_step:04d}_rgb', t_pred, self.epoch, dataformats='NCHW')
-                        self.writer.add_image(f'{self.name}_{self.local_step:04d}_depth', t_pred_depth, self.epoch)                    
+                        self.writer.add_image(f'{self.name}/{self.local_step:04d}_rgb', t_pred, self.epoch, dataformats='NCHW')
+                        self.writer.add_image(f'{self.name}/{self.local_step:04d}_depth', t_pred_depth, self.epoch)                    
                     
                     cv2.imwrite(save_path, cv2.cvtColor(pred, cv2.COLOR_RGB2BGR))
                     cv2.imwrite(save_path_depth, pred_depth)

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -859,6 +859,15 @@ class Trainer(object):
                     pred_depth = preds_depth[0].detach().cpu().numpy()
                     pred_depth = (pred_depth - pred_depth.min()) / (pred_depth.max() - pred_depth.min() + 1e-6)
                     pred_depth = (pred_depth * 255).astype(np.uint8)
+
+                    if tensorboardX:
+                        #convert to tensor
+                        t_pred = torch.from_numpy(pred).permute(2, 0, 1).unsqueeze(0)
+                        t_pred_depth = torch.from_numpy(pred_depth).unsqueeze(0)
+                    
+                        #add as image
+                        self.writer.add_image(f'{self.name}_{self.local_step:04d}_rgb', t_pred, self.epoch, dataformats='NCHW')
+                        self.writer.add_image(f'{self.name}_{self.local_step:04d}_depth', t_pred_depth, self.epoch)                    
                     
                     cv2.imwrite(save_path, cv2.cvtColor(pred, cv2.COLOR_RGB2BGR))
                     cv2.imwrite(save_path_depth, pred_depth)

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -266,7 +266,9 @@ class Trainer(object):
             self.log_path = os.path.join(workspace, f"log_{self.name}.txt")
             self.log_ptr = open(self.log_path, "a+")
 
-            self.ckpt_path = os.path.join(self.workspace, 'checkpoints')
+            # joint self.name to self.workspace
+            workspace_name = os.path.join(self.workspace, self.name)
+            self.ckpt_path = os.path.join(workspace_name, 'checkpoints')
             self.best_path = f"{self.ckpt_path}/{self.name}.pth"
             os.makedirs(self.ckpt_path, exist_ok=True)
         


### PR DESCRIPTION
adding images to tensorboard so that they are nice to view.

adding --name argument to create of the same --text-prompt project other runs with other settings like --cuda-ray or else.
If you use e.g.  --name "seed=100,cuda-ray"   for one run, and --name "seed=300,cuda-ray"  for the next run, you can easily compare the data in tensorboard.

If you dont use it, it defaults to "df".

<img width="887" alt="tensorboard" src="https://user-images.githubusercontent.com/11964445/219434123-c609a06a-219b-4b23-83f8-223714c9db32.png">

<img width="835" alt="tensorboard1" src="https://user-images.githubusercontent.com/11964445/219434155-eef78ff0-b6d2-4156-82ea-455aae243302.png">
