### PR TITLE
[backend] Add a taichi backend

### DIFF
--- a/encoding.py
+++ b/encoding.py
@@ -70,7 +70,7 @@ def get_encoder(encoding, input_dim=3,
         encoder = GridEncoder(input_dim=input_dim, num_levels=num_levels, level_dim=level_dim, base_resolution=base_resolution, log2_hashmap_size=log2_hashmap_size, desired_resolution=desired_resolution, gridtype='tiled', align_corners=align_corners, interpolation=interpolation)
     
     elif encoding == 'hashgrid_taichi':
-        from taichi_models.taichi_modules.hash_encoder import HashEncoder
+        from taichi_modules.hash_encoder import HashEncoder
         encoder = HashEncoder(batch_size=4096) #TODO: hard encoded batch size
 
     else:

--- a/encoding.py
+++ b/encoding.py
@@ -68,6 +68,10 @@ def get_encoder(encoding, input_dim=3,
     elif encoding == 'tiledgrid':
         from gridencoder import GridEncoder
         encoder = GridEncoder(input_dim=input_dim, num_levels=num_levels, level_dim=level_dim, base_resolution=base_resolution, log2_hashmap_size=log2_hashmap_size, desired_resolution=desired_resolution, gridtype='tiled', align_corners=align_corners, interpolation=interpolation)
+    
+    elif encoding == 'hashgrid_taichi':
+        from taichi_models.taichi_modules.hash_encoder import HashEncoder
+        encoder = HashEncoder(batch_size=4096) #TODO: hard encoded batch size
 
     else:
         raise NotImplementedError('Unknown encoding mode, choose from [None, frequency, sphere_harmonics, hashgrid, tiledgrid]')

--- a/main.py
+++ b/main.py
@@ -127,8 +127,6 @@ if __name__ == '__main__':
     model = NeRFNetwork(opt)
 
     print(model)
-    for i in model.encoder.parameters():
-        print(i.shape)
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 

--- a/main.py
+++ b/main.py
@@ -108,12 +108,15 @@ if __name__ == '__main__':
     elif opt.backbone == 'grid':
         from nerf.network_grid import NeRFNetwork
     elif opt.backbone == 'grid_taichi':
-        print("select grid taichi.")
         opt.cuda_ray = False
         opt.taichi_ray = True
         import taichi as ti
         from nerf.network_grid_taichi import NeRFNetwork
-        ti.init(arch=ti.cuda, device_memory_GB=4)
+        taichi_half2_opt = True
+        taichi_init_args = {"arch": ti.cuda, "device_memory_GB": 4.0}
+        if taichi_half2_opt:
+            taichi_init_args["half2_vectorization"] = True
+        ti.init(**taichi_init_args)
     else:
         raise NotImplementedError(f'--backbone {opt.backbone} is not implemented!')
 

--- a/nerf/network_grid_taichi.py
+++ b/nerf/network_grid_taichi.py
@@ -1,0 +1,156 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from activation import trunc_exp
+from .renderer import NeRFRenderer
+
+import numpy as np
+from encoding import get_encoder
+
+from .utils import safe_normalize
+
+class MLP(nn.Module):
+    def __init__(self, dim_in, dim_out, dim_hidden, num_layers, bias=True):
+        super().__init__()
+        self.dim_in = dim_in
+        self.dim_out = dim_out
+        self.dim_hidden = dim_hidden
+        self.num_layers = num_layers
+
+        net = []
+        for l in range(num_layers):
+            net.append(nn.Linear(self.dim_in if l == 0 else self.dim_hidden, self.dim_out if l == num_layers - 1 else self.dim_hidden, bias=bias))
+
+        self.net = nn.ModuleList(net)
+    
+    def forward(self, x):
+        for l in range(self.num_layers):
+            x = self.net[l](x)
+            if l != self.num_layers - 1:
+                x = F.relu(x, inplace=True)
+        return x
+
+
+class NeRFNetwork(NeRFRenderer):
+    def __init__(self, 
+                 opt,
+                 num_layers=1,
+                 hidden_dim=32,
+                 num_layers_bg=2,
+                 hidden_dim_bg=16,
+                 ):
+        
+        super().__init__(opt)
+
+        self.num_layers = num_layers
+        self.hidden_dim = hidden_dim
+
+        # print("get the hashgrid taichi encoder")
+
+        self.encoder, self.in_dim = get_encoder('hashgrid_taichi', input_dim=3, log2_hashmap_size=19, desired_resolution=2048 * self.bound, interpolation='smoothstep')
+
+        self.sigma_net = MLP(self.in_dim, 4, hidden_dim, num_layers, bias=True)
+        self.normal_net = MLP(self.in_dim, 3, hidden_dim, num_layers, bias=True)
+
+        self.density_activation = trunc_exp if self.opt.density_activation == 'exp' else F.softplus
+
+        # background network
+        if self.bg_radius > 0:
+            self.num_layers_bg = num_layers_bg   
+            self.hidden_dim_bg = hidden_dim_bg
+            
+            # use a very simple network to avoid it learning the prompt...
+            self.encoder_bg, self.in_dim_bg = get_encoder('frequency', input_dim=3, multires=4)
+            self.bg_net = MLP(self.in_dim_bg, 3, hidden_dim_bg, num_layers_bg, bias=True)
+            
+        else:
+            self.bg_net = None
+
+    # add a density blob to the scene center
+    def density_blob(self, x):
+        # x: [B, N, 3]
+        
+        d = (x ** 2).sum(-1)
+        # g = self.opt.blob_density * torch.exp(- d / (self.opt.blob_radius ** 2))
+        g = self.opt.blob_density * (1 - torch.sqrt(d) / self.opt.blob_radius)
+
+        return g
+
+    def common_forward(self, x):
+
+        # sigma
+        enc = self.encoder(x, bound=self.bound)
+
+        h = self.sigma_net(enc)
+
+        sigma = self.density_activation(h[..., 0] + self.density_blob(x))
+        albedo = torch.sigmoid(h[..., 1:])
+
+        return sigma, albedo, enc
+    
+    def forward(self, x, d, l=None, ratio=1, shading='albedo'):
+        # x: [N, 3], in [-bound, bound]
+        # d: [N, 3], view direction, nomalized in [-1, 1]
+        # l: [3], plane light direction, nomalized in [-1, 1]
+        # ratio: scalar, ambient ratio, 1 == no shading (albedo only), 0 == only shading (textureless)
+
+        sigma, albedo, enc = self.common_forward(x)
+
+        if shading == 'albedo':
+            normal = None
+            color = albedo
+        
+        else: # lambertian shading
+            normal = self.normal_net(enc)
+            normal = safe_normalize(normal)
+            normal = torch.nan_to_num(normal)
+
+            lambertian = ratio + (1 - ratio) * (normal @ l).clamp(min=0) # [N,]
+
+            if shading == 'textureless':
+                color = lambertian.unsqueeze(-1).repeat(1, 3)
+            elif shading == 'normal':
+                color = (normal + 1) / 2
+            else: # 'lambertian'
+                color = albedo * lambertian.unsqueeze(-1)
+            
+        return sigma, color, normal
+
+      
+    def density(self, x):
+        # x: [N, 3], in [-bound, bound]
+        
+        sigma, albedo, _ = self.common_forward(x)
+        
+        return {
+            'sigma': sigma,
+            'albedo': albedo,
+        }
+
+
+    def background(self, d):
+
+        h = self.encoder_bg(d) # [N, C]
+        
+        h = self.bg_net(h)
+
+        # sigmoid activation for rgb
+        rgbs = torch.sigmoid(h)
+
+        return rgbs
+
+    # optimizer utils
+    def get_params(self, lr):
+
+        params = [
+            {'params': self.encoder.parameters(), 'lr': lr * 10},
+            {'params': self.sigma_net.parameters(), 'lr': lr},
+            {'params': self.normal_net.parameters(), 'lr': lr},
+        ]        
+
+        if self.bg_radius > 0:
+            # params.append({'params': self.encoder_bg.parameters(), 'lr': lr * 10})
+            params.append({'params': self.bg_net.parameters(), 'lr': lr})
+
+        return params

--- a/nerf/renderer.py
+++ b/nerf/renderer.py
@@ -3,6 +3,7 @@ import math
 import cv2
 import trimesh
 import numpy as np
+from einops import rearrange
 
 import torch
 import torch.nn as nn
@@ -12,6 +13,12 @@ import mcubes
 import raymarching
 from meshutils import decimate_mesh, clean_mesh, poisson_mesh_reconstruction
 from .utils import custom_meshgrid, safe_normalize
+from taichi_models.taichi_modules import RayMarcher as RayMarcherTaichi
+from taichi_models.taichi_modules import VolumeRendererTaichi
+from taichi_models.taichi_modules import RayAABBIntersector
+from taichi_models.taichi_modules import raymarching_test as raymarching_test_taichi
+from taichi_models.taichi_modules import composite_test as composite_test_fw
+
 
 def sample_pdf(bins, weights, n_samples, det=False):
     # This implementation is from NeRF
@@ -97,6 +104,7 @@ class NeRFRenderer(nn.Module):
         self.cascade = 1 + math.ceil(math.log2(opt.bound))
         self.grid_size = 128
         self.cuda_ray = opt.cuda_ray
+        self.taichi_ray = opt.taichi_ray
         self.min_near = opt.min_near
         self.density_thresh = opt.density_thresh
         self.bg_radius = opt.bg_radius
@@ -122,7 +130,22 @@ class NeRFRenderer(nn.Module):
             self.register_buffer('step_counter', step_counter)
             self.mean_count = 0
             self.local_step = 0
-
+        
+        if self.taichi_ray:
+            self.ray_marching = RayMarcherTaichi(batch_size=4096) # TODO: hard encoded batch size
+            self.render_func = VolumeRendererTaichi(batch_size=4096) # TODO: hard encoded batch size
+            # density grid
+            density_grid = torch.zeros([self.cascade, self.grid_size ** 3]) # [CAS, H * H * H]
+            density_bitfield = torch.zeros(self.cascade * self.grid_size ** 3 // 8, dtype=torch.uint8) # [CAS * H * H * H // 8]
+            self.register_buffer('density_grid', density_grid)
+            self.register_buffer('density_bitfield', density_bitfield)
+            self.mean_density = 0
+            self.iter_density = 0
+            # step counter
+            step_counter = torch.zeros(16, 2, dtype=torch.int32) # 16 is hardcoded for averaging...
+            self.register_buffer('step_counter', step_counter)
+            self.mean_count = 0
+            self.local_step = 0
     
     def forward(self, x, d):
         raise NotImplementedError()
@@ -134,7 +157,7 @@ class NeRFRenderer(nn.Module):
         raise NotImplementedError()
 
     def reset_extra_state(self):
-        if not self.cuda_ray:
+        if not (self.cuda_ray or self.taichi_ray):
             return 
         # density grid
         self.density_grid.zero_()
@@ -496,7 +519,6 @@ class NeRFRenderer(nn.Module):
             counter = self.step_counter[self.local_step % 16]
             counter.zero_() # set to 0
             self.local_step += 1
-
             xyzs, dirs, ts, rays = raymarching.march_rays_train(rays_o, rays_d, self.bound, self.density_bitfield, self.cascade, self.grid_size, nears, fars, perturb, dt_gamma, max_steps)
             # plot_pointcloud(xyzs.reshape(-1, 3).detach().cpu().numpy())
             sigmas, rgbs, normals = self(xyzs, dirs, light_d, ratio=ambient_ratio, shading=shading)
@@ -569,11 +591,143 @@ class NeRFRenderer(nn.Module):
         return results
 
 
+    def run_taichi(self, rays_o, rays_d, dt_gamma=0, light_d=None, ambient_ratio=1.0, shading='albedo', bg_color=None, perturb=False, force_all_rays=False, max_steps=1024, T_thresh=1e-4, **kwargs):
+        # rays_o, rays_d: [B, N, 3], assumes B == 1
+        # return: image: [B, N, 3], depth: [B, N]
+
+        prefix = rays_o.shape[:-1]
+        rays_o = rays_o.contiguous().view(-1, 3)
+        rays_d = rays_d.contiguous().view(-1, 3)
+
+        N = rays_o.shape[0] # N = B * N, in fact
+        device = rays_o.device
+
+        # pre-calculate near far
+        # nears, fars = raymarching.near_far_from_aabb(rays_o, rays_d, self.aabb_train if self.training else self.aabb_infer)
+        exp_step_factor = kwargs.get('exp_step_factor', 0.)
+        MAX_SAMPLES = 1024
+        NEAR_DISTANCE = 0.01
+        center = torch.zeros(1, 3)
+        half_size = torch.ones(1, 3)
+        _, hits_t, _ = RayAABBIntersector.apply(rays_o, rays_d, center, half_size, 1)
+        hits_t[(hits_t[:, 0, 0] >= 0) & (hits_t[:, 0, 0] < NEAR_DISTANCE), 0, 0] = NEAR_DISTANCE
+
+        # random sample light_d if not provided
+        if light_d is None:
+            # gaussian noise around the ray origin, so the light always face the view dir (avoid dark face)
+            light_d = (rays_o[0] + torch.randn(3, device=device, dtype=torch.float))
+            light_d = safe_normalize(light_d)
+
+        results = {}
+
+        if self.training:
+            # setup counter
+            counter = self.step_counter[self.local_step % 16]
+            counter.zero_() # set to 0
+            self.local_step += 1
+            rays_a, xyzs, dirs, deltas, ts, _ = self.ray_marching(rays_o, rays_d, hits_t[:, 0], self.density_bitfield, self.cascade, self.bound, exp_step_factor, self.grid_size, MAX_SAMPLES)
+            # plot_pointcloud(xyzs.reshape(-1, 3).detach().cpu().numpy())
+            sigmas, rgbs, normals = self(xyzs, dirs, light_d, ratio=ambient_ratio, shading=shading)
+            _, weights_sum, depth, image, weights = self.render_func(sigmas, rgbs, deltas, ts, rays_a, kwargs.get('T_threshold', 1e-4))
+            
+            # normals related regularizations
+            if normals is not None:
+                # orientation loss 
+                loss_orient = weights.detach() * (normals * dirs).sum(-1).clamp(min=0) ** 2
+                results['loss_orient'] = loss_orient.mean()
+            
+            # weights normalization
+            results['weights'] = weights
+
+        else:
+        
+            # allocate outputs 
+            dtype = torch.float32
+            
+            weights_sum = torch.zeros(N, dtype=dtype, device=device)
+            depth = torch.zeros(N, dtype=dtype, device=device)
+            image = torch.zeros(N, 3, dtype=dtype, device=device)
+            
+            n_alive = N
+            rays_alive = torch.arange(n_alive, dtype=torch.int32, device=device) # [N]
+            rays_t = hits_t[:, 0, 0]
+            step = 0
+            
+            min_samples = 1 if exp_step_factor == 0 else 4
+
+            while step < max_steps: # hard coded max step
+
+                # count alive rays 
+                n_alive = rays_alive.shape[0]
+
+                # exit loop
+                if n_alive <= 0:
+                    break
+
+                # decide compact_steps
+                # n_step = max(min(N // n_alive, 8), 1)
+                n_step = max(min(N // n_alive, 64), min_samples)
+
+                xyzs, dirs, deltas, ts, N_eff_samples = \
+                raymarching_test_taichi(rays_o, rays_d, hits_t[:, 0], rays_alive,
+                                    self.density_bitfield, self.cascade,
+                                    self.bound, exp_step_factor,
+                                    self.grid_size, MAX_SAMPLES, n_step)
+                # print(f"[Test] Ray marching after xyzs {xyzs.shape}, dirs {dirs.shape}, ts {ts.shape}")
+                xyzs = rearrange(xyzs, 'n1 n2 c -> (n1 n2) c')
+                dirs = rearrange(dirs, 'n1 n2 c -> (n1 n2) c')
+                valid_mask = ~torch.all(dirs == 0, dim=1)
+                if valid_mask.sum() == 0:
+                    break
+
+                sigmas = torch.zeros(len(xyzs), device=device)
+                rgbs = torch.zeros(len(xyzs), 3, device=device)
+                normals = torch.zeros(len(xyzs), 3, device=device)
+
+                # xyzs, dirs, ts = raymarching.march_rays(n_alive, n_step, rays_alive, rays_t, rays_o, rays_d, self.bound, self.density_bitfield, self.cascade, self.grid_size, nears, fars, perturb if step == 0 else False, dt_gamma, max_steps)
+                sigmas[valid_mask], _rgbs, normals = self(xyzs[valid_mask], dirs[valid_mask], light_d, ratio=ambient_ratio, shading=shading)
+                rgbs[valid_mask] = _rgbs.float()
+                sigmas = rearrange(sigmas, '(n1 n2) -> n1 n2', n2=n_step)
+                rgbs = rearrange(rgbs, '(n1 n2) c -> n1 n2 c', n2=n_step)
+                if normals is not None:
+                    normals = rearrange(normals, '(n1 n2) c -> n1 n2 c', n2=n_step)
+
+                # raymarching.composite_rays(n_alive, n_step, rays_alive, rays_t, sigmas, rgbs, ts, weights_sum, depth, image, T_thresh)
+                composite_test_fw(sigmas, rgbs, deltas, ts, hits_t[:,0], rays_alive,
+                                    kwargs.get('T_threshold', 1e-4), N_eff_samples,
+                                    weights_sum, depth, image)
+
+                rays_alive = rays_alive[rays_alive >= 0]
+
+                step += n_step
+
+        # mix background color
+        if self.bg_radius > 0:
+            # use the bg model to calculate bg_color
+            bg_color = self.background(rays_d) # [N, 3]
+
+        elif bg_color is None:
+            bg_color = 1
+
+        image = image + rearrange(1 - weights_sum, 'n -> n 1') * bg_color
+        image = image.view(*prefix, 3)
+
+        depth = depth.view(*prefix)
+
+        weights_sum = weights_sum.reshape(*prefix)
+
+        results['image'] = image
+        results['depth'] = depth
+        results['weights_sum'] = weights_sum
+        
+        return results
+
+
     @torch.no_grad()
     def update_extra_state(self, decay=0.95, S=128):
         # call before each epoch to update extra states.
 
-        if not self.cuda_ray:
+        if not (self.cuda_ray or self.taichi_ray):
             return 
         
         ### update density grid
@@ -605,7 +759,6 @@ class NeRFRenderer(nn.Module):
                         sigmas = self.density(cas_xyzs)['sigma'].reshape(-1).detach()
                         # assign 
                         tmp_grid[cas, indices] = sigmas
-        
         # ema update
         valid_mask = self.density_grid >= 0
         self.density_grid[valid_mask] = torch.maximum(self.density_grid[valid_mask] * decay, tmp_grid[valid_mask])
@@ -631,6 +784,8 @@ class NeRFRenderer(nn.Module):
 
         if self.cuda_ray:
             _run = self.run_cuda
+        elif self.taichi_ray:
+            _run = self.run_taichi
         else:
             _run = self.run
 
@@ -638,7 +793,7 @@ class NeRFRenderer(nn.Module):
         device = rays_o.device
 
         # never stage when cuda_ray
-        if staged and not self.cuda_ray:
+        if staged and not (self.cuda_ray or self.taichi_ray):
             depth = torch.empty((B, N), device=device)
             image = torch.empty((B, N, 3), device=device)
             weights_sum = torch.empty((B, N), device=device)

--- a/nerf/renderer.py
+++ b/nerf/renderer.py
@@ -13,11 +13,11 @@ import mcubes
 import raymarching
 from meshutils import decimate_mesh, clean_mesh, poisson_mesh_reconstruction
 from .utils import custom_meshgrid, safe_normalize
-from taichi_models.taichi_modules import RayMarcher as RayMarcherTaichi
-from taichi_models.taichi_modules import VolumeRendererTaichi
-from taichi_models.taichi_modules import RayAABBIntersector
-from taichi_models.taichi_modules import raymarching_test as raymarching_test_taichi
-from taichi_models.taichi_modules import composite_test as composite_test_fw
+from taichi_modules import RayMarcher as RayMarcherTaichi
+from taichi_modules import VolumeRenderer as VolumeRendererTaichi
+from taichi_modules import RayAABBIntersector
+from taichi_modules import raymarching_test as raymarching_test_taichi
+from taichi_modules import composite_test as composite_test_fw
 
 
 def sample_pdf(bins, weights, n_samples, det=False):

--- a/nerf/utils.py
+++ b/nerf/utils.py
@@ -736,7 +736,7 @@ class Trainer(object):
         for data in loader:
             
             # update grid every 16 steps
-            if self.model.cuda_ray and self.global_step % self.opt.update_extra_interval == 0:
+            if (self.model.cuda_ray or self.model.taichi_ray) and self.global_step % self.opt.update_extra_interval == 0:
                 with torch.cuda.amp.autocast(enabled=self.fp16):
                     self.model.update_extra_state()
                     

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ The original paper's project page: [_DreamFusion: Text-to-3D using 2D Diffusion_
 
 **NEWS (2023.1.30)**: Generation quality is better with many improvements proposed by [Magic3D](https://deepimagination.cc/Magic3D/)!
 
+**NEWS (2023.3.12)**: A [Taichi](https://github.com/taichi-dev/taichi) backend is available for Instant-NGP. **No CUDA** build is requied while it achieves comparable performance!
+
 https://user-images.githubusercontent.com/25863658/215996308-9fd959f5-b5c7-4a8e-a241-0fe63ec86a4a.mp4
 
 Colab notebooks: 
@@ -58,6 +60,12 @@ bash scripts/install_ext.sh
 pip install ./raymarching # install to python path (you still need the raymarching/ folder, since this only installs the built extension.)
 ```
 
+### Taichi backend (optional)
+Use [Taichi](https://github.com/taichi-dev/taichi) backend for Instant-NGP. It achieves comparable performance to CUDA implementation while **No CUDA** build is required. Install Taichi with pip: 
+```bash
+pip install taichi
+```
+
 ### Tested environments
 * Ubuntu 22 with torch 1.12 & CUDA 11.6 on a V100.
 
@@ -72,7 +80,7 @@ First time running will take some time to compile the CUDA extensions.
 ### Instant-NGP NeRF Backbone 
 # + faster rendering speed
 # + less GPU memory (~16G)
-# - need to build CUDA extensions
+# - need to build CUDA extensions (a CUDA-free Taichi backend is available)
 # - worse surface quality
 
 ## train with text prompt (with the default settings)
@@ -81,6 +89,9 @@ First time running will take some time to compile the CUDA extensions.
 # `--fp16` enables half-precision training.
 # `--dir_text` enables view-dependent prompting.
 python main.py --text "a hamburger" --workspace trial -O
+
+# use CUDA-free Taichi backend with `--backbone grid_taichi`
+python3 main.py --text "a hamburger" --workspace trial -O --backbone grid_taichi
 
 # choose stable-diffusion version (support 1.5, 2.0 and 2.1, default is 2.1 now)
 python main.py --text "a hamburger" --workspace trial -O --sd_version 1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ imageio-ffmpeg
 accelerate
 tensorboard
 pymeshlab
+einops

--- a/taichi_modules/__init__.py
+++ b/taichi_modules/__init__.py
@@ -1,0 +1,4 @@
+from .ray_march import RayMarcher, raymarching_test
+from .volume_train import VolumeRenderer
+from .intersection import RayAABBIntersector
+from .volume_render_test import composite_test

--- a/taichi_modules/__init__.py
+++ b/taichi_modules/__init__.py
@@ -2,3 +2,4 @@ from .ray_march import RayMarcher, raymarching_test
 from .volume_train import VolumeRenderer
 from .intersection import RayAABBIntersector
 from .volume_render_test import composite_test
+from .utils import packbits

--- a/taichi_modules/hash_encoder.py
+++ b/taichi_modules/hash_encoder.py
@@ -1,0 +1,305 @@
+import numpy as np
+import taichi as ti
+import torch
+from taichi.math import uvec3
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+from .utils import (data_type, ti2torch, ti2torch_grad, ti2torch_grad_vec,
+                    ti2torch_vec, torch2ti, torch2ti_grad, torch2ti_grad_vec,
+                    torch2ti_vec, torch_type)
+
+half2 = ti.types.vector(n=2, dtype=ti.f16)
+
+
+@ti.kernel
+def random_initialize(data: ti.types.ndarray()):
+    for I in ti.grouped(data):
+        data[I] = (ti.random() * 2.0 - 1.0) * 1e-4
+
+
+@ti.kernel
+def ti_copy(data1: ti.template(), data2: ti.template()):
+    for I in ti.grouped(data1):
+        data1[I] = data2[I]
+
+
+@ti.kernel
+def ti_copy_array(data1: ti.types.ndarray(), data2: ti.types.ndarray()):
+    for I in ti.grouped(data1):
+        data1[I] = data2[I]
+
+
+@ti.kernel
+def ti_copy_field_array(data1: ti.template(), data2: ti.types.ndarray()):
+    for I in ti.grouped(data1):
+        data1[I] = data2[I]
+
+
+@ti.func
+def fast_hash(pos_grid_local):
+    result = ti.uint32(0)
+    # primes = uvec3(ti.uint32(1), ti.uint32(1958374283), ti.uint32(2654435761))
+    primes = uvec3(ti.uint32(1), ti.uint32(2654435761), ti.uint32(805459861))
+    for i in ti.static(range(3)):
+        result ^= ti.uint32(pos_grid_local[i]) * primes[i]
+    return result
+
+
+@ti.func
+def under_hash(pos_grid_local, resolution):
+    result = ti.uint32(0)
+    stride = ti.uint32(1)
+    for i in ti.static(range(3)):
+        result += ti.uint32(pos_grid_local[i] * stride)
+        stride *= resolution
+    return result
+
+
+@ti.func
+def grid_pos2hash_index(indicator, pos_grid_local, resolution, map_size):
+    hash_result = ti.uint32(0)
+    if indicator == 1:
+        hash_result = under_hash(pos_grid_local, resolution)
+    else:
+        hash_result = fast_hash(pos_grid_local)
+
+    return hash_result % map_size
+
+
+@ti.kernel
+def hash_encode_kernel(
+        xyzs: ti.template(), table: ti.template(),
+        xyzs_embedding: ti.template(), hash_map_indicator: ti.template(),
+        hash_map_sizes_field: ti.template(), offsets: ti.template(), B: ti.i32,
+        per_level_scale: ti.f32):
+
+    # get hash table embedding
+    ti.loop_config(block_dim=16)
+    for i, level in ti.ndrange(B, 16):
+        xyz = ti.Vector([xyzs[i, 0], xyzs[i, 1], xyzs[i, 2]])
+
+        scale = 16 * ti.exp(level * ti.log(per_level_scale)) - 1.0
+        resolution = ti.cast(ti.ceil(scale), ti.uint32) + 1
+
+        offset = offsets[level] * 2
+
+        pos = xyz * scale + 0.5
+        pos_grid_uint = ti.cast(ti.floor(pos), ti.uint32)
+        pos -= pos_grid_uint
+
+        indicator = hash_map_indicator[level]
+        map_size = hash_map_sizes_field[level]
+
+        local_feature_0 = 0.0
+        local_feature_1 = 0.0
+
+        for idx in ti.static(range(8)):
+            w = 1.
+            pos_grid_local = uvec3(0)
+
+            for d in ti.static(range(3)):
+                if (idx & (1 << d)) == 0:
+                    pos_grid_local[d] = pos_grid_uint[d]
+                    w *= 1 - pos[d]
+                else:
+                    pos_grid_local[d] = pos_grid_uint[d] + 1
+                    w *= pos[d]
+
+            index = grid_pos2hash_index(indicator, pos_grid_local, resolution,
+                                        map_size)
+            index_table = offset + index * 2
+            index_table_int = ti.cast(index_table, ti.int32)
+            local_feature_0 += w * table[index_table_int]
+            local_feature_1 += w * table[index_table_int + 1]
+
+        xyzs_embedding[i, level * 2] = local_feature_0
+        xyzs_embedding[i, level * 2 + 1] = local_feature_1
+
+
+@ti.kernel
+def hash_encode_kernel_half2(
+        xyzs: ti.template(), table: ti.template(),
+        xyzs_embedding: ti.template(), hash_map_indicator: ti.template(),
+        hash_map_sizes_field: ti.template(), offsets: ti.template(), B: ti.i32,
+        per_level_scale: ti.f16):
+
+    # get hash table embedding
+    ti.loop_config(block_dim=32)
+    for i, level in ti.ndrange(B, 16):
+        xyz = ti.Vector([xyzs[i, 0], xyzs[i, 1], xyzs[i, 2]])
+
+        scale = 16 * ti.exp(level * ti.log(per_level_scale)) - 1.0
+        resolution = ti.cast(ti.ceil(scale), ti.uint32) + 1
+
+        offset = offsets[level]
+
+        pos = xyz * scale + 0.5
+        pos_grid_uint = ti.cast(ti.floor(pos), ti.uint32)
+        pos -= pos_grid_uint
+
+        indicator = hash_map_indicator[level]
+        map_size = hash_map_sizes_field[level]
+
+        local_feature = half2(0.0)
+        for idx in ti.static(range(8)):
+            w = ti.f32(1.0)
+            pos_grid_local = uvec3(0)
+
+            for d in ti.static(range(3)):
+                if (idx & (1 << d)) == 0:
+                    pos_grid_local[d] = pos_grid_uint[d]
+                    w *= 1 - pos[d]
+                else:
+                    pos_grid_local[d] = pos_grid_uint[d] + 1
+                    w *= pos[d]
+
+            index = grid_pos2hash_index(indicator, pos_grid_local, resolution,
+                                        map_size)
+
+            index_table = offset + index
+            index_table_int = ti.cast(index_table, ti.int32)
+
+            local_feature += w * table[index_table_int]
+        xyzs_embedding[i, level] = local_feature
+
+
+class HashEncoder(torch.nn.Module):
+
+    def __init__(self,
+                 b=1.3195079565048218,
+                 batch_size=8192,
+                 data_type=data_type,
+                 half2_opt=False):
+        super(HashEncoder, self).__init__()
+
+        self.per_level_scale = b
+        if batch_size < 2048:
+            batch_size = 2048
+
+        # per_level_scale = 1.3195079565048218
+        print("per_level_scale: ", b)
+        self.offsets = ti.field(ti.i32, shape=(16, ))
+        self.hash_map_sizes_field = ti.field(ti.uint32, shape=(16, ))
+        self.hash_map_indicator = ti.field(ti.i32, shape=(16, ))
+        base_res = 16
+        max_params = 2**19
+        offset_ = 0
+        hash_map_sizes = []
+        for i in range(16):
+            resolution = int(
+                np.ceil(base_res * np.exp(i * np.log(self.per_level_scale)) -
+                        1.0)) + 1
+            params_in_level = resolution**3
+            params_in_level = int(resolution**
+                                  3) if params_in_level % 8 == 0 else int(
+                                      (params_in_level + 8 - 1) / 8) * 8
+            params_in_level = min(max_params, params_in_level)
+            self.offsets[i] = offset_
+            hash_map_sizes.append(params_in_level)
+            self.hash_map_indicator[
+                i] = 1 if resolution**3 <= params_in_level else 0
+            offset_ += params_in_level
+        print("offset_: ", offset_)
+        size = np.uint32(np.array(hash_map_sizes))
+        self.hash_map_sizes_field.from_numpy(size)
+
+        self.total_hash_size = offset_ * 2
+        print("total_hash_size: ", self.total_hash_size)
+
+        self.hash_table = torch.nn.Parameter(torch.zeros(self.total_hash_size,
+                                                         dtype=torch_type),
+                                             requires_grad=True)
+        random_initialize(self.hash_table)
+
+        if half2_opt:
+            assert self.total_hash_size % 2 == 0
+            self.parameter_fields = half2.field(shape=(self.total_hash_size //
+                                                       2, ),
+                                                needs_grad=True)
+            self.output_fields = half2.field(shape=(batch_size * 1024, 16),
+                                             needs_grad=True)
+
+            self.torch2ti = torch2ti_vec
+            self.ti2torch = ti2torch_vec
+            self.ti2torch_grad = ti2torch_grad_vec
+            self.torch2ti_grad = torch2ti_grad_vec
+
+            self._hash_encode_kernel = hash_encode_kernel_half2
+        else:
+            self.parameter_fields = ti.field(data_type,
+                                             shape=(self.total_hash_size, ),
+                                             needs_grad=True)
+            self.output_fields = ti.field(dtype=data_type,
+                                          shape=(batch_size * 1024, 32),
+                                          needs_grad=True)
+            self.torch2ti = torch2ti
+            self.ti2torch = ti2torch
+            self.ti2torch_grad = ti2torch_grad
+            self.torch2ti_grad = torch2ti_grad
+
+            self._hash_encode_kernel = hash_encode_kernel
+
+        self.input_fields = ti.field(dtype=data_type,
+                                     shape=(batch_size * 1024, 3),
+                                     needs_grad=True)
+        self.output_dim = 32 # the output dim: num levels (16) x level num (2)
+        self.register_buffer(
+            'hash_grad', torch.zeros(self.total_hash_size, dtype=torch_type))
+        self.register_buffer(
+            'output_embedding',
+            torch.zeros(batch_size * 1024, 32, dtype=torch_type))
+
+        class _module_function(torch.autograd.Function):
+
+            @staticmethod
+            @custom_fwd(cast_inputs=torch_type)
+            def forward(ctx, input_pos, params):
+                output_embedding = self.output_embedding[:input_pos.
+                                                         shape[0]].contiguous(
+                                                         )
+                torch2ti(self.input_fields, input_pos.contiguous())
+                self.torch2ti(self.parameter_fields, params.contiguous())
+
+                self._hash_encode_kernel(
+                    self.input_fields,
+                    self.parameter_fields,
+                    self.output_fields,
+                    self.hash_map_indicator,
+                    self.hash_map_sizes_field,
+                    self.offsets,
+                    input_pos.shape[0],
+                    self.per_level_scale,
+                )
+                self.ti2torch(self.output_fields, output_embedding)
+
+                return output_embedding
+
+            @staticmethod
+            @custom_bwd
+            def backward(ctx, doutput):
+
+                self.zero_grad()
+
+                self.torch2ti_grad(self.output_fields, doutput.contiguous())
+                self._hash_encode_kernel.grad(
+                    self.input_fields,
+                    self.parameter_fields,
+                    self.output_fields,
+                    self.hash_map_indicator,
+                    self.hash_map_sizes_field,
+                    self.offsets,
+                    doutput.shape[0],
+                    self.per_level_scale,
+                )
+                self.ti2torch_grad(self.parameter_fields,
+                                   self.hash_grad.contiguous())
+                return None, self.hash_grad
+
+        self._module_function = _module_function
+
+    def zero_grad(self):
+        self.parameter_fields.grad.fill(0.)
+
+    def forward(self, positions, bound=1):
+        positions = (positions + bound) / (2 * bound) 
+        return self._module_function.apply(positions, self.hash_table)

--- a/taichi_modules/intersection.py
+++ b/taichi_modules/intersection.py
@@ -61,16 +61,8 @@ class RayAABBIntersector(torch.autograd.Function):
         hits_t = (torch.zeros(
             rays_o.size(0), 1, 2, device=rays_o.device, dtype=torch.float32) -
                   1).contiguous()
-        # hits_voxel_idx = (torch.zeros(rays_o.size(0), max_hits, device=rays_o.device, dtype=torch.int64) - 1).contiguous()
-        # hit_cnt = torch.empty(rays_o.size(0), device=rays_o.device)
-        # taichi_kernel.ray_aabb_intersec_taichi_forward(hits_t, hits_voxel_idx, hit_cnt, rays_o, rays_d, center, half_size, max_hits)
+
         simple_ray_aabb_intersec_taichi_forward(hits_t, rays_o, rays_d, center,
                                                 half_size)
-
-        # ti.sync()
-
-        # hits_order = torch.sort(hits_t[..., 0])[1]
-        # hits_voxel_idx = torch.gather(hits_voxel_idx, 1, hits_order)
-        # hits_t = torch.gather(hits_t, 1, hits_order.unsqueeze(-1).tile((1, 1, 2)))
 
         return None, hits_t, None

--- a/taichi_modules/intersection.py
+++ b/taichi_modules/intersection.py
@@ -1,0 +1,76 @@
+import taichi as ti
+import torch
+from taichi.math import vec3
+from torch.cuda.amp import custom_fwd
+
+from .utils import NEAR_DISTANCE
+
+
+@ti.kernel
+def simple_ray_aabb_intersec_taichi_forward(
+        hits_t: ti.types.ndarray(field_dim=2),
+        rays_o: ti.types.ndarray(field_dim=2),
+        rays_d: ti.types.ndarray(field_dim=2),
+        centers: ti.types.ndarray(field_dim=2),
+        half_sizes: ti.types.ndarray(field_dim=2)):
+
+    for r in ti.ndrange(hits_t.shape[0]):
+        ray_o = vec3([rays_o[r, 0], rays_o[r, 1], rays_o[r, 2]])
+        ray_d = vec3([rays_d[r, 0], rays_d[r, 1], rays_d[r, 2]])
+        inv_d = 1.0 / ray_d
+
+        center = vec3([centers[0, 0], centers[0, 1], centers[0, 2]])
+        half_size = vec3(
+            [half_sizes[0, 0], half_sizes[0, 1], half_sizes[0, 1]])
+
+        t_min = (center - half_size - ray_o) * inv_d
+        t_max = (center + half_size - ray_o) * inv_d
+
+        _t1 = ti.min(t_min, t_max)
+        _t2 = ti.max(t_min, t_max)
+        t1 = _t1.max()
+        t2 = _t2.min()
+
+        if t2 > 0.0:
+            hits_t[r, 0, 0] = ti.max(t1, NEAR_DISTANCE)
+            hits_t[r, 0, 1] = t2
+
+
+class RayAABBIntersector(torch.autograd.Function):
+    """
+    Computes the intersections of rays and axis-aligned voxels.
+
+    Inputs:
+        rays_o: (N_rays, 3) ray origins
+        rays_d: (N_rays, 3) ray directions
+        centers: (N_voxels, 3) voxel centers
+        half_sizes: (N_voxels, 3) voxel half sizes
+        max_hits: maximum number of intersected voxels to keep for one ray
+                  (for a cubic scene, this is at most 3*N_voxels^(1/3)-2)
+
+    Outputs:
+        hits_cnt: (N_rays) number of hits for each ray
+        (followings are from near to far)
+        hits_t: (N_rays, max_hits, 2) hit t's (-1 if no hit)
+        hits_voxel_idx: (N_rays, max_hits) hit voxel indices (-1 if no hit)
+    """
+
+    @staticmethod
+    @custom_fwd(cast_inputs=torch.float32)
+    def forward(ctx, rays_o, rays_d, center, half_size, max_hits):
+        hits_t = (torch.zeros(
+            rays_o.size(0), 1, 2, device=rays_o.device, dtype=torch.float32) -
+                  1).contiguous()
+        # hits_voxel_idx = (torch.zeros(rays_o.size(0), max_hits, device=rays_o.device, dtype=torch.int64) - 1).contiguous()
+        # hit_cnt = torch.empty(rays_o.size(0), device=rays_o.device)
+        # taichi_kernel.ray_aabb_intersec_taichi_forward(hits_t, hits_voxel_idx, hit_cnt, rays_o, rays_d, center, half_size, max_hits)
+        simple_ray_aabb_intersec_taichi_forward(hits_t, rays_o, rays_d, center,
+                                                half_size)
+
+        # ti.sync()
+
+        # hits_order = torch.sort(hits_t[..., 0])[1]
+        # hits_voxel_idx = torch.gather(hits_voxel_idx, 1, hits_order)
+        # hits_t = torch.gather(hits_t, 1, hits_order.unsqueeze(-1).tile((1, 1, 2)))
+
+        return None, hits_t, None

--- a/taichi_modules/ray_march.py
+++ b/taichi_modules/ray_march.py
@@ -1,0 +1,340 @@
+import taichi as ti
+import torch
+from taichi.math import vec3
+from torch.cuda.amp import custom_fwd
+
+from .utils import __morton3D, calc_dt, mip_from_dt, mip_from_pos
+
+
+@ti.kernel
+def raymarching_train(rays_o: ti.types.ndarray(field_dim=2),
+                      rays_d: ti.types.ndarray(field_dim=2),
+                      hits_t: ti.types.ndarray(field_dim=2),
+                      density_bitfield: ti.types.ndarray(field_dim=1),
+                      noise: ti.types.ndarray(field_dim=1),
+                      counter: ti.types.ndarray(field_dim=1),
+                      rays_a: ti.types.ndarray(field_dim=2),
+                      xyzs: ti.types.ndarray(field_dim=2),
+                      dirs: ti.types.ndarray(field_dim=2),
+                      deltas: ti.types.ndarray(field_dim=1),
+                      ts: ti.types.ndarray(field_dim=1), cascades: int,
+                      grid_size: int, scale: float, exp_step_factor: float,
+                      max_samples: float):
+
+    # ti.loop_config(block_dim=256)
+    for r in noise:
+        ray_o = vec3(rays_o[r, 0], rays_o[r, 1], rays_o[r, 2])
+        ray_d = vec3(rays_d[r, 0], rays_d[r, 1], rays_d[r, 2])
+        d_inv = 1.0 / ray_d
+
+        t1, t2 = hits_t[r, 0], hits_t[r, 1]
+
+        grid_size3 = grid_size**3
+        grid_size_inv = 1.0 / grid_size
+
+        if t1 >= 0:
+            dt = calc_dt(t1, exp_step_factor, grid_size, scale)
+            t1 += dt * noise[r]
+
+        t = t1
+        N_samples = 0
+
+        while (0 <= t) & (t < t2) & (N_samples < max_samples):
+            xyz = ray_o + t * ray_d
+            dt = calc_dt(t, exp_step_factor, grid_size, scale)
+            mip = ti.max(mip_from_pos(xyz, cascades),
+                         mip_from_dt(dt, grid_size, cascades))
+
+            # mip_bound = 0.5
+            # mip_bound = ti.min(ti.pow(2., mip - 1), scale)
+            mip_bound = scale
+            mip_bound_inv = 1 / mip_bound
+
+            nxyz = ti.math.clamp(0.5 * (xyz * mip_bound_inv + 1) * grid_size,
+                                 0.0, grid_size - 1.0)
+            # nxyz = ti.ceil(nxyz)
+
+            idx = mip * grid_size3 + __morton3D(ti.cast(nxyz, ti.u32))
+            occ = density_bitfield[ti.u32(idx // 8)] & (1 << ti.u32(idx % 8))
+            # idx = __morton3D(ti.cast(nxyz, ti.uint32))
+            # occ = density_bitfield[mip, idx//8] & (1 << ti.cast(idx%8, ti.uint32))
+
+            if occ:
+                t += dt
+                N_samples += 1
+            else:
+                # t += dt
+                txyz = (((nxyz + 0.5 + 0.5 * ti.math.sign(ray_d)) *
+                         grid_size_inv * 2 - 1) * mip_bound - xyz) * d_inv
+
+                t_target = t + ti.max(0, txyz.min())
+                t += calc_dt(t, exp_step_factor, grid_size, scale)
+                while t < t_target:
+                    t += calc_dt(t, exp_step_factor, grid_size, scale)
+
+        start_idx = ti.atomic_add(counter[0], N_samples)
+        ray_count = ti.atomic_add(counter[1], 1)
+
+        rays_a[ray_count, 0] = r
+        rays_a[ray_count, 1] = start_idx
+        rays_a[ray_count, 2] = N_samples
+
+        t = t1
+        samples = 0
+
+        while (t < t2) & (samples < N_samples):
+            xyz = ray_o + t * ray_d
+            dt = calc_dt(t, exp_step_factor, grid_size, scale)
+            mip = ti.max(mip_from_pos(xyz, cascades),
+                         mip_from_dt(dt, grid_size, cascades))
+
+            # mip_bound = 0.5
+            # mip_bound = ti.min(ti.pow(2., mip - 1), scale)
+            mip_bound = scale
+            mip_bound_inv = 1 / mip_bound
+
+            nxyz = ti.math.clamp(0.5 * (xyz * mip_bound_inv + 1) * grid_size,
+                                 0.0, grid_size - 1.0)
+            # nxyz = ti.ceil(nxyz)
+
+            idx = mip * grid_size3 + __morton3D(ti.cast(nxyz, ti.u32))
+            occ = density_bitfield[ti.u32(idx // 8)] & (1 << ti.u32(idx % 8))
+            # idx = __morton3D(ti.cast(nxyz, ti.uint32))
+            # occ = density_bitfield[mip, idx//8] & (1 << ti.cast(idx%8, ti.uint32))
+
+            if occ:
+                s = start_idx + samples
+                xyzs[s, 0] = xyz[0]
+                xyzs[s, 1] = xyz[1]
+                xyzs[s, 2] = xyz[2]
+                dirs[s, 0] = ray_d[0]
+                dirs[s, 1] = ray_d[1]
+                dirs[s, 2] = ray_d[2]
+                ts[s] = t
+                deltas[s] = dt
+                t += dt
+                samples += 1
+            else:
+                # t += dt
+                txyz = (((nxyz + 0.5 + 0.5 * ti.math.sign(ray_d)) *
+                         grid_size_inv * 2 - 1) * mip_bound - xyz) * d_inv
+
+                t_target = t + ti.max(0, txyz.min())
+                t += calc_dt(t, exp_step_factor, grid_size, scale)
+                while t < t_target:
+                    t += calc_dt(t, exp_step_factor, grid_size, scale)
+
+
+@ti.kernel
+def raymarching_train_backword(segments: ti.types.ndarray(field_dim=2),
+                               ts: ti.types.ndarray(field_dim=1),
+                               dL_drays_o: ti.types.ndarray(field_dim=2),
+                               dL_drays_d: ti.types.ndarray(field_dim=2),
+                               dL_dxyzs: ti.types.ndarray(field_dim=2),
+                               dL_ddirs: ti.types.ndarray(field_dim=2)):
+
+    for s in segments:
+        index = segments[s]
+        dxyz = dL_dxyzs[index]
+        ddir = dL_ddirs[index]
+
+        dL_drays_o[s] = dxyz
+        dL_drays_d[s] = dxyz * ts[index] + ddir
+
+
+class RayMarcher(torch.nn.Module):
+
+    def __init__(self, batch_size=8192):
+        super(RayMarcher, self).__init__()
+
+        self.register_buffer('rays_a',
+                             torch.zeros(batch_size, 3, dtype=torch.int32))
+        self.register_buffer(
+            'xyzs', torch.zeros(batch_size * 1024, 3, dtype=torch.float32))
+        self.register_buffer(
+            'dirs', torch.zeros(batch_size * 1024, 3, dtype=torch.float32))
+        self.register_buffer(
+            'deltas', torch.zeros(batch_size * 1024, dtype=torch.float32))
+        self.register_buffer(
+            'ts', torch.zeros(batch_size * 1024, dtype=torch.float32))
+
+        # self.register_buffer('dL_drays_o', torch.zeros(batch_size, dtype=torch.float32))
+        # self.register_buffer('dL_drays_d', torch.zeros(batch_size, dtype=torch.float32))
+
+        class _module_function(torch.autograd.Function):
+
+            @staticmethod
+            @custom_fwd(cast_inputs=torch.float32)
+            def forward(ctx, rays_o, rays_d, hits_t, density_bitfield,
+                        cascades, scale, exp_step_factor, grid_size,
+                        max_samples):
+                # noise to perturb the first sample of each ray
+                noise = torch.rand_like(rays_o[:, 0])
+                counter = torch.zeros(2,
+                                      device=rays_o.device,
+                                      dtype=torch.int32)
+
+                raymarching_train(\
+                    rays_o, rays_d,
+                    hits_t.contiguous(),
+                    density_bitfield, noise, counter,
+                    self.rays_a.contiguous(),
+                    self.xyzs.contiguous(),
+                    self.dirs.contiguous(),
+                    self.deltas.contiguous(),
+                    self.ts.contiguous(),
+                    cascades, grid_size, scale,
+                    exp_step_factor, max_samples)
+
+                # ti.sync()
+
+                total_samples = counter[0]  # total samples for all rays
+                # remove redundant output
+                xyzs = self.xyzs[:total_samples]
+                dirs = self.dirs[:total_samples]
+                deltas = self.deltas[:total_samples]
+                ts = self.ts[:total_samples]
+
+                return self.rays_a, xyzs, dirs, deltas, ts, total_samples
+
+                # @staticmethod
+                # @custom_bwd
+                # def backward(ctx, dL_drays_a, dL_dxyzs, dL_ddirs, dL_ddeltas, dL_dts,
+                #              dL_dtotal_samples):
+                #     rays_a, ts = ctx.saved_tensors
+                #     # rays_a = rays_a.contiguous()
+                #     ts = ts.contiguous()
+                #     segments = torch.cat([rays_a[:, 1], rays_a[-1:, 1] + rays_a[-1:, 2]])
+                #     dL_drays_o = torch.zeros_like(rays_a[:, 0])
+                #     dL_drays_d = torch.zeros_like(rays_a[:, 0])
+                #     raymarching_train_backword(segments.contiguous(), ts, dL_drays_o,
+                #                                dL_drays_d, dL_dxyzs, dL_ddirs)
+                #     # ti.sync()
+                #     # dL_drays_o = segment_csr(dL_dxyzs, segments)
+                #     # dL_drays_d = \
+                #     #     segment_csr(dL_dxyzs*rearrange(ts, 'n -> n 1')+dL_ddirs, segments)
+
+                #     return dL_drays_o, dL_drays_d, None, None, None, None, None, None, None
+
+        self._module_function = _module_function
+
+    def forward(self, rays_o, rays_d, hits_t, density_bitfield, cascades,
+                scale, exp_step_factor, grid_size, max_samples):
+        return self._module_function.apply(rays_o, rays_d, hits_t,
+                                           density_bitfield, cascades, scale,
+                                           exp_step_factor, grid_size,
+                                           max_samples)
+
+
+@ti.kernel
+def raymarching_test_kernel(
+        rays_o: ti.types.ndarray(field_dim=2),
+        rays_d: ti.types.ndarray(field_dim=2),
+        hits_t: ti.types.ndarray(field_dim=2),
+        alive_indices: ti.types.ndarray(field_dim=1),
+        density_bitfield: ti.types.ndarray(field_dim=1),
+        cascades: int,
+        grid_size: int,
+        scale: float,
+        exp_step_factor: float,
+        N_samples: int,
+        max_samples: int,
+        xyzs: ti.types.ndarray(field_dim=2),
+        dirs: ti.types.ndarray(field_dim=2),
+        deltas: ti.types.ndarray(field_dim=1),
+        ts: ti.types.ndarray(field_dim=1),
+        N_eff_samples: ti.types.ndarray(field_dim=1),
+):
+
+    for n in alive_indices:
+        r = alive_indices[n]
+        grid_size3 = grid_size**3
+        grid_size_inv = 1.0 / grid_size
+
+        ray_o = vec3(rays_o[r, 0], rays_o[r, 1], rays_o[r, 2])
+        ray_d = vec3(rays_d[r, 0], rays_d[r, 1], rays_d[r, 2])
+        d_inv = 1.0 / ray_d
+
+        t = hits_t[r, 0]
+        t2 = hits_t[r, 1]
+
+        s = 0
+
+        while (0 <= t) & (t < t2) & (s < N_samples):
+            xyz = ray_o + t * ray_d
+            dt = calc_dt(t, exp_step_factor, grid_size, scale)
+            mip = ti.max(mip_from_pos(xyz, cascades),
+                         mip_from_dt(dt, grid_size, cascades))
+
+            # mip_bound = 0.5
+            # mip_bound = ti.min(ti.pow(2., mip - 1), scale)
+            mip_bound = scale
+            mip_bound_inv = 1 / mip_bound
+
+            nxyz = ti.math.clamp(0.5 * (xyz * mip_bound_inv + 1) * grid_size,
+                                 0.0, grid_size - 1.0)
+            # nxyz = ti.ceil(nxyz)
+
+            idx = mip * grid_size3 + __morton3D(ti.cast(nxyz, ti.u32))
+            occ = density_bitfield[ti.u32(idx // 8)] & (1 << ti.u32(idx % 8))
+
+            if occ:
+                xyzs[n, s, 0] = xyz[0]
+                xyzs[n, s, 1] = xyz[1]
+                xyzs[n, s, 2] = xyz[2]
+                dirs[n, s, 0] = ray_d[0]
+                dirs[n, s, 1] = ray_d[1]
+                dirs[n, s, 2] = ray_d[2]
+                ts[n, s] = t
+                deltas[n, s] = dt
+                t += dt
+                hits_t[r, 0] = t
+                s += 1
+
+            else:
+                txyz = (((nxyz + 0.5 + 0.5 * ti.math.sign(ray_d)) *
+                         grid_size_inv * 2 - 1) * mip_bound - xyz) * d_inv
+
+                t_target = t + ti.max(0, txyz.min())
+                t += calc_dt(t, exp_step_factor, grid_size, scale)
+                while t < t_target:
+                    t += calc_dt(t, exp_step_factor, grid_size, scale)
+
+        N_eff_samples[n] = s
+
+
+def raymarching_test(rays_o, rays_d, hits_t, alive_indices, density_bitfield,
+                     cascades, scale, exp_step_factor, grid_size, max_samples,
+                     N_samples):
+
+    N_rays = alive_indices.size(0)
+    xyzs = torch.zeros(N_rays,
+                       N_samples,
+                       3,
+                       device=rays_o.device,
+                       dtype=rays_o.dtype)
+    dirs = torch.zeros(N_rays,
+                       N_samples,
+                       3,
+                       device=rays_o.device,
+                       dtype=rays_o.dtype)
+    deltas = torch.zeros(N_rays,
+                         N_samples,
+                         device=rays_o.device,
+                         dtype=rays_o.dtype)
+    ts = torch.zeros(N_rays,
+                     N_samples,
+                     device=rays_o.device,
+                     dtype=rays_o.dtype)
+    N_eff_samples = torch.zeros(N_rays,
+                                device=rays_o.device,
+                                dtype=torch.int32)
+
+    raymarching_test_kernel(rays_o, rays_d, hits_t, alive_indices,
+                            density_bitfield, cascades, grid_size, scale,
+                            exp_step_factor, N_samples, max_samples, xyzs,
+                            dirs, deltas, ts, N_eff_samples)
+
+    # ti.sync()
+
+    return xyzs, dirs, deltas, ts, N_eff_samples

--- a/taichi_modules/utils.py
+++ b/taichi_modules/utils.py
@@ -1,0 +1,224 @@
+import taichi as ti
+import torch
+from taichi.math import uvec3
+
+taichi_block_size = 128
+
+data_type = ti.f32
+torch_type = torch.float32
+
+MAX_SAMPLES = 1024
+NEAR_DISTANCE = 0.01
+SQRT3 = 1.7320508075688772
+SQRT3_MAX_SAMPLES = SQRT3 / 1024
+SQRT3_2 = 1.7320508075688772 * 2
+
+
+@ti.func
+def scalbn(x, exponent):
+    return x * ti.math.pow(2, exponent)
+
+
+@ti.func
+def calc_dt(t, exp_step_factor, grid_size, scale):
+    return ti.math.clamp(t * exp_step_factor, SQRT3_MAX_SAMPLES,
+                         SQRT3_2 * scale / grid_size)
+
+
+@ti.func
+def frexp_bit(x):
+    exponent = 0
+    if x != 0.0:
+        # frac = ti.abs(x)
+        bits = ti.bit_cast(x, ti.u32)
+        exponent = ti.i32((bits & ti.u32(0x7f800000)) >> 23) - 127
+        # exponent = (ti.i32(bits & ti.u32(0x7f800000)) >> 23) - 127
+        bits &= ti.u32(0x7fffff)
+        bits |= ti.u32(0x3f800000)
+        frac = ti.bit_cast(bits, ti.f32)
+        if frac < 0.5:
+            exponent -= 1
+        elif frac > 1.0:
+            exponent += 1
+    return exponent
+
+
+@ti.func
+def mip_from_pos(xyz, cascades):
+    mx = ti.abs(xyz).max()
+    # _, exponent = _frexp(mx)
+    exponent = frexp_bit(ti.f32(mx)) + 1
+    # frac, exponent = ti.frexp(ti.f32(mx))
+    return ti.min(cascades - 1, ti.max(0, exponent))
+
+
+@ti.func
+def mip_from_dt(dt, grid_size, cascades):
+    # _, exponent = _frexp(dt*grid_size)
+    exponent = frexp_bit(ti.f32(dt * grid_size))
+    # frac, exponent = ti.frexp(ti.f32(dt*grid_size))
+    return ti.min(cascades - 1, ti.max(0, exponent))
+
+
+@ti.func
+def __expand_bits(v):
+    v = (v * ti.uint32(0x00010001)) & ti.uint32(0xFF0000FF)
+    v = (v * ti.uint32(0x00000101)) & ti.uint32(0x0F00F00F)
+    v = (v * ti.uint32(0x00000011)) & ti.uint32(0xC30C30C3)
+    v = (v * ti.uint32(0x00000005)) & ti.uint32(0x49249249)
+    return v
+
+
+@ti.func
+def __morton3D(xyz):
+    xyz = __expand_bits(xyz)
+    return xyz[0] | (xyz[1] << 1) | (xyz[2] << 2)
+
+
+@ti.func
+def __morton3D_invert(x):
+    x = x & (0x49249249)
+    x = (x | (x >> 2)) & ti.uint32(0xc30c30c3)
+    x = (x | (x >> 4)) & ti.uint32(0x0f00f00f)
+    x = (x | (x >> 8)) & ti.uint32(0xff0000ff)
+    x = (x | (x >> 16)) & ti.uint32(0x0000ffff)
+    return ti.int32(x)
+
+
+@ti.kernel
+def morton3D_invert_kernel(indices: ti.types.ndarray(field_dim=1),
+                           coords: ti.types.ndarray(field_dim=2)):
+    for i in indices:
+        ind = ti.uint32(indices[i])
+        coords[i, 0] = __morton3D_invert(ind >> 0)
+        coords[i, 1] = __morton3D_invert(ind >> 1)
+        coords[i, 2] = __morton3D_invert(ind >> 2)
+
+
+def morton3D_invert(indices):
+    coords = torch.zeros(indices.size(0),
+                         3,
+                         device=indices.device,
+                         dtype=torch.int32)
+    morton3D_invert_kernel(indices.contiguous(), coords)
+    ti.sync()
+    return coords
+
+
+@ti.kernel
+def morton3D_kernel(xyzs: ti.types.ndarray(field_dim=2),
+                    indices: ti.types.ndarray(field_dim=1)):
+    for s in indices:
+        xyz = uvec3([xyzs[s, 0], xyzs[s, 1], xyzs[s, 2]])
+        indices[s] = ti.cast(__morton3D(xyz), ti.int32)
+
+
+def morton3D(coords1):
+    indices = torch.zeros(coords1.size(0),
+                          device=coords1.device,
+                          dtype=torch.int32)
+    morton3D_kernel(coords1.contiguous(), indices)
+    ti.sync()
+    return indices
+
+
+@ti.kernel
+def packbits(density_grid: ti.types.ndarray(field_dim=1),
+             density_threshold: float,
+             density_bitfield: ti.types.ndarray(field_dim=1)):
+
+    for n in density_bitfield:
+        bits = ti.uint8(0)
+
+        for i in ti.static(range(8)):
+            bits |= (ti.uint8(1) << i) if (
+                density_grid[8 * n + i] > density_threshold) else ti.uint8(0)
+
+        density_bitfield[n] = bits
+
+
+@ti.kernel
+def torch2ti(field: ti.template(), data: ti.types.ndarray()):
+    for I in ti.grouped(data):
+        field[I] = data[I]
+
+
+@ti.kernel
+def ti2torch(field: ti.template(), data: ti.types.ndarray()):
+    for I in ti.grouped(data):
+        data[I] = field[I]
+
+
+@ti.kernel
+def ti2torch_grad(field: ti.template(), grad: ti.types.ndarray()):
+    for I in ti.grouped(grad):
+        grad[I] = field.grad[I]
+
+
+@ti.kernel
+def torch2ti_grad(field: ti.template(), grad: ti.types.ndarray()):
+    for I in ti.grouped(grad):
+        field.grad[I] = grad[I]
+
+
+@ti.kernel
+def torch2ti_vec(field: ti.template(), data: ti.types.ndarray()):
+    for I in range(data.shape[0] // 2):
+        field[I] = ti.Vector([data[I * 2], data[I * 2 + 1]])
+
+
+@ti.kernel
+def ti2torch_vec(field: ti.template(), data: ti.types.ndarray()):
+    for i, j in ti.ndrange(data.shape[0], data.shape[1] // 2):
+        data[i, j * 2] = field[i, j][0]
+        data[i, j * 2 + 1] = field[i, j][1]
+
+
+@ti.kernel
+def ti2torch_grad_vec(field: ti.template(), grad: ti.types.ndarray()):
+    for I in range(grad.shape[0] // 2):
+        grad[I * 2] = field.grad[I][0]
+        grad[I * 2 + 1] = field.grad[I][1]
+
+
+@ti.kernel
+def torch2ti_grad_vec(field: ti.template(), grad: ti.types.ndarray()):
+    for i, j in ti.ndrange(grad.shape[0], grad.shape[1] // 2):
+        field.grad[i, j][0] = grad[i, j * 2]
+        field.grad[i, j][1] = grad[i, j * 2 + 1]
+
+
+def extract_model_state_dict(ckpt_path,
+                             model_name='model',
+                             prefixes_to_ignore=[]):
+    checkpoint = torch.load(ckpt_path, map_location='cpu')
+    checkpoint_ = {}
+    if 'state_dict' in checkpoint:  # if it's a pytorch-lightning checkpoint
+        checkpoint = checkpoint['state_dict']
+    for k, v in checkpoint.items():
+        if not k.startswith(model_name):
+            continue
+        k = k[len(model_name) + 1:]
+        for prefix in prefixes_to_ignore:
+            if k.startswith(prefix):
+                break
+        else:
+            checkpoint_[k] = v
+    return checkpoint_
+
+
+def load_ckpt(model, ckpt_path, model_name='model', prefixes_to_ignore=[]):
+    if not ckpt_path:
+        return
+    model_dict = model.state_dict()
+    checkpoint_ = extract_model_state_dict(ckpt_path, model_name,
+                                           prefixes_to_ignore)
+    model_dict.update(checkpoint_)
+    model.load_state_dict(model_dict)
+
+def depth2img(depth):
+    depth = (depth - depth.min()) / (depth.max() - depth.min())
+    depth_img = cv2.applyColorMap((depth * 255).astype(np.uint8),
+                                  cv2.COLORMAP_TURBO)
+
+    return depth_img

--- a/taichi_modules/volume_train.py
+++ b/taichi_modules/volume_train.py
@@ -1,0 +1,280 @@
+import taichi as ti
+import torch
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+from .utils import (data_type, ti2torch, ti2torch_grad, torch2ti,
+                    torch2ti_grad, torch_type)
+
+
+@ti.kernel
+def composite_train_fw_array(
+        sigmas: ti.types.ndarray(),
+        rgbs: ti.types.ndarray(),
+        deltas: ti.types.ndarray(),
+        ts: ti.types.ndarray(),
+        rays_a: ti.types.ndarray(),
+        T_threshold: float,
+        total_samples: ti.types.ndarray(),
+        opacity: ti.types.ndarray(),
+        depth: ti.types.ndarray(),
+        rgb: ti.types.ndarray(),
+        ws: ti.types.ndarray(),
+):
+
+    for n in opacity:
+        ray_idx = rays_a[n, 0]
+        start_idx = rays_a[n, 1]
+        N_samples = rays_a[n, 2]
+
+        T = 1.0
+        samples = 0
+        while samples < N_samples:
+            s = start_idx + samples
+            a = 1.0 - ti.exp(-sigmas[s] * deltas[s])
+            w = a * T
+
+            rgb[ray_idx, 0] += w * rgbs[s, 0]
+            rgb[ray_idx, 1] += w * rgbs[s, 1]
+            rgb[ray_idx, 2] += w * rgbs[s, 2]
+            depth[ray_idx] += w * ts[s]
+            opacity[ray_idx] += w
+            ws[s] = w
+            T *= 1.0 - a
+
+            # if T<T_threshold:
+            #     break
+            samples += 1
+
+        total_samples[ray_idx] = samples
+
+
+@ti.kernel
+def composite_train_fw(sigmas: ti.template(), rgbs: ti.template(),
+                       deltas: ti.template(), ts: ti.template(),
+                       rays_a: ti.template(), T_threshold: float,
+                       T: ti.template(), total_samples: ti.template(),
+                       opacity: ti.template(), depth: ti.template(),
+                       rgb: ti.template(), ws: ti.template()):
+
+    ti.loop_config(block_dim=256)
+    for n in opacity:
+        ray_idx = ti.i32(rays_a[n, 0])
+        start_idx = ti.i32(rays_a[n, 1])
+        N_samples = ti.i32(rays_a[n, 2])
+
+        rgb[ray_idx, 0] = 0.0
+        rgb[ray_idx, 1] = 0.0
+        rgb[ray_idx, 2] = 0.0
+        depth[ray_idx] = 0.0
+        opacity[ray_idx] = 0.0
+        total_samples[ray_idx] = 0
+
+        T[start_idx] = 1.0
+        # T_ = 1.0
+        # samples = 0
+        # while samples<N_samples:
+        for sample_ in range(N_samples):
+            # T_ = T[ray_idx, samples]
+            s = start_idx + sample_
+            T_ = T[s]
+            if T_ > T_threshold:
+                # s = start_idx + sample_
+                a = 1.0 - ti.exp(-sigmas[s] * deltas[s])
+                w = a * T_
+                rgb[ray_idx, 0] += w * rgbs[s, 0]
+                rgb[ray_idx, 1] += w * rgbs[s, 1]
+                rgb[ray_idx, 2] += w * rgbs[s, 2]
+                depth[ray_idx] += w * ts[s]
+                opacity[ray_idx] += w
+                ws[s] = w
+                # T_ *= (1.0-a)
+                T[s + 1] = T_ * (1.0 - a)
+                # if T[s+1]>=T_threshold:
+                # samples += 1
+                total_samples[ray_idx] += 1
+            else:
+                T[s + 1] = 0.0
+
+        # total_samples[ray_idx] = N_samples
+
+
+@ti.kernel
+def check_value(
+        fields: ti.template(),
+        array: ti.types.ndarray(),
+        checker: ti.types.ndarray(),
+):
+    for I in ti.grouped(array):
+        if fields[I] == array[I]:
+            checker[I] = 1
+
+
+class VolumeRenderer(torch.nn.Module):
+
+    def __init__(self, batch_size=8192, data_type=data_type):
+        super(VolumeRenderer, self).__init__()
+        # samples level
+        self.sigmas_fields = ti.field(dtype=data_type,
+                                      shape=(batch_size * 1024, ),
+                                      needs_grad=True)
+        self.rgbs_fields = ti.field(dtype=data_type,
+                                    shape=(batch_size * 1024, 3),
+                                    needs_grad=True)
+        self.deltas_fields = ti.field(dtype=data_type,
+                                      shape=(batch_size * 1024, ),
+                                      needs_grad=True)
+        self.ts_fields = ti.field(dtype=data_type,
+                                  shape=(batch_size * 1024, ),
+                                  needs_grad=True)
+        self.ws_fields = ti.field(dtype=data_type,
+                                  shape=(batch_size * 1024, ),
+                                  needs_grad=True)
+        self.T = ti.field(dtype=data_type,
+                          shape=(batch_size * 1024),
+                          needs_grad=True)
+        # self.a = ti.field(dtype=data_type, shape=(8192*1024), needs_grad=True)
+        # rays level
+        self.rays_a_fields = ti.field(dtype=ti.i64, shape=(batch_size, 3))
+        self.total_samples_fields = ti.field(dtype=ti.i64,
+                                             shape=(batch_size, ))
+        self.opacity_fields = ti.field(dtype=data_type,
+                                       shape=(batch_size, ),
+                                       needs_grad=True)
+        self.depth_fields = ti.field(dtype=data_type,
+                                     shape=(batch_size, ),
+                                     needs_grad=True)
+        self.rgb_fields = ti.field(dtype=data_type,
+                                   shape=(batch_size, 3),
+                                   needs_grad=True)
+
+        # self.T = ti.field(dtype=data_type, shape=(8192, 1024), needs_grad=True)
+
+        # preallocate tensor
+        self.register_buffer('total_samples',
+                             torch.zeros(batch_size, dtype=torch.int64))
+        self.register_buffer('rgb', torch.zeros(batch_size,
+                                                3,
+                                                dtype=torch_type))
+        self.register_buffer('opacity',
+                             torch.zeros(batch_size, dtype=torch_type))
+        self.register_buffer('depth', torch.zeros(batch_size,
+                                                  dtype=torch_type))
+        self.register_buffer('ws',
+                             torch.zeros(batch_size * 1024, dtype=torch_type))
+
+        self.register_buffer('sigma_grad',
+                             torch.zeros(batch_size * 1024, dtype=torch_type))
+        self.register_buffer(
+            'rgb_grad', torch.zeros(batch_size * 1024, 3, dtype=torch_type))
+
+        class _module_function(torch.autograd.Function):
+
+            @staticmethod
+            @custom_fwd(cast_inputs=torch_type)
+            def forward(ctx, sigmas, rgbs, deltas, ts, rays_a, T_threshold):
+                # If no output gradient is provided, no need to
+                # automatically materialize it as torch.zeros.
+
+                # ctx.set_materialize_grads(False) # maybe not needed
+                ctx.T_threshold = T_threshold
+                rays_size = rays_a.shape[0]
+                # ctx.rays_size = rays_size
+                ctx.samples_size = sigmas.shape[0]
+                # total_samples = torch.zeros(rays_size,
+                #                             dtype=torch.int64,
+                #                             device=rays_a.device)
+                # rgb = torch.zeros(rays_size,
+                #                   3,
+                #                   dtype=torch_type,
+                #                   device=rays_a.device)
+                # opacity = torch.zeros(rays_size,
+                #                       dtype=torch_type,
+                #                       device=rays_a.device)
+                # depth = torch.zeros(rays_size,
+                #                     dtype=torch_type,
+                #                     device=rays_a.device)
+                # ws = torch.zeros_like(sigmas)
+
+                ws = self.ws[:sigmas.shape[0]]
+
+                torch2ti(self.sigmas_fields, sigmas.contiguous())
+                torch2ti(self.rgbs_fields, rgbs.contiguous())
+                torch2ti(self.deltas_fields, deltas.contiguous())
+                torch2ti(self.ts_fields, ts.contiguous())
+                torch2ti(self.rays_a_fields, rays_a.contiguous())
+                composite_train_fw(self.sigmas_fields, self.rgbs_fields,
+                                   self.deltas_fields, self.ts_fields,
+                                   self.rays_a_fields, T_threshold, self.T,
+                                   self.total_samples_fields,
+                                   self.opacity_fields, self.depth_fields,
+                                   self.rgb_fields, self.ws_fields)
+                ti2torch(self.total_samples_fields, self.total_samples)
+                ti2torch(self.opacity_fields, self.opacity)
+                ti2torch(self.depth_fields, self.depth)
+                ti2torch(self.rgb_fields, self.rgb)
+                # ti2torch(self.total_samples_fields, total_samples)
+                # ti2torch(self.opacity_fields, opacity)
+                # ti2torch(self.depth_fields, depth)
+                # ti2torch(self.rgb_fields, rgb)
+                # ti2torch(self.ws_fields, ws)
+
+                return self.total_samples.sum(
+                ), self.opacity, self.depth, self.rgb, ws
+                # return total_samples.sum(), opacity, depth, rgb, ws
+
+            @staticmethod
+            @custom_bwd
+            def backward(ctx, dL_dtotal_samples, dL_dopacity, dL_ddepth,
+                         dL_drgb, dL_dws):
+
+                T_threshold = ctx.T_threshold
+                # rays_size = ctx.rays_size
+                samples_size = ctx.samples_size
+                # create new tensor for saving sigma and rgb gradient from taichi field
+                # sigma_grad = torch.zeros(samples_size,
+                #                          dtype=torch_type,
+                #                          device=dL_dws.device)
+                # rgb_grad = torch.zeros(samples_size,
+                #                        3,
+                #                        dtype=torch_type,
+                #                        device=dL_dws.device)
+
+                sigma_grad = self.sigma_grad[:samples_size].contiguous()
+                rgb_grad = self.rgb_grad[:samples_size].contiguous()
+
+                self.zero_grad()
+
+                torch2ti_grad(self.opacity_fields, dL_dopacity.contiguous())
+                torch2ti_grad(self.depth_fields, dL_ddepth.contiguous())
+                torch2ti_grad(self.rgb_fields, dL_drgb.contiguous())
+                torch2ti_grad(self.ws_fields, dL_dws.contiguous())
+                composite_train_fw.grad(self.sigmas_fields, self.rgbs_fields,
+                                        self.deltas_fields, self.ts_fields,
+                                        self.rays_a_fields, T_threshold,
+                                        self.T, self.total_samples_fields,
+                                        self.opacity_fields, self.depth_fields,
+                                        self.rgb_fields, self.ws_fields)
+                ti2torch_grad(self.sigmas_fields, sigma_grad)
+                ti2torch_grad(self.rgbs_fields, rgb_grad)
+
+                return sigma_grad, rgb_grad, None, None, None, None
+
+        self._module_function = _module_function
+
+    def zero_grad(self):
+
+        self.sigmas_fields.grad.fill(0.)
+        self.rgbs_fields.grad.fill(0.)
+        # self.deltas_fields.grad.fill(0.)
+        # self.ts_fields.grad.fill(0.)
+        # self.ws_fields.grad.fill(0.)
+        self.T.grad.fill(0.)
+        # rays level
+        # self.opacity_fields.grad.fill(0.)
+        # self.depth_fields.grad.fill(0.)
+        # self.rgb_fields.grad.fill(0.)
+        # self.ws_fields.grad.fill(0.)
+
+    def forward(self, sigmas, rgbs, deltas, ts, rays_a, T_threshold):
+        return self._module_function.apply(sigmas, rgbs, deltas, ts, rays_a,
+                                           T_threshold)


### PR DESCRIPTION
# Add a Taichi Backend
## Motivation
The current instant-ngp backbone requires building CUDA extensions. It requires extra efforts for the users. In addition, the official pre-built torch and cuda-toolkit version should be consistent. Sometimes there is no official provided torch with specific cuda version, e.g., cuda 11.4. Either building torch from source or re-installing cuda with required version is annoying . Thus, I would like a Taichi backend, which can achieve **CUDA-free**, i.e., a purely Pytorch + Taichi implementation. Users only need to `pip install -r requirements.txt` and `pip install taichi` and then starts to play with the model.

## Implementation
The key components of instant-ngp  `raymarching`,`hash encoder` and `volume renderer` are implemented using Taichi. 
The corresponding backward kernel are generated by Taichi autodiff automatically.

## Performance
The training performance is comparable to cuda implementation. It is tested on RTX 3090 using the case `a hamburger`. For 100 epochs, Taichi backend takes ~35 mins and cuda takes ~32 mins.

## Visual Results
The training process of "a hamburger" using Taichi backend. 
`python3 main.py --text "a hamburger" -O --backbone grid_taichi --workspace taichi_result`

<img src="https://user-images.githubusercontent.com/33411325/223989298-c32dac12-471b-41ca-8375-dd96be51a13a.gif"  width="50%" height="50%">

