### PR TITLE
Adds --vram_O option

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -106,7 +106,7 @@ print(f'[INFO] loading models..')
 
 if opt.guidance == 'stable-diffusion':
     from sd import StableDiffusion
-    guidance = StableDiffusion(device, opt.sd_version, opt.hf_key)
+    guidance = StableDiffusion(device, opt.memory_saving_sd_config, opt.sd_version, opt.hf_key)
 elif opt.guidance == 'clip':
     from nerf.clip import CLIP
     guidance = CLIP(device)

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -106,7 +106,7 @@ print(f'[INFO] loading models..')
 
 if opt.guidance == 'stable-diffusion':
     from sd import StableDiffusion
-    guidance = StableDiffusion(device, opt.memory_saving_sd_config, opt.sd_version, opt.hf_key)
+    guidance = StableDiffusion(device, opt.vram_O, opt.sd_version, opt.hf_key)
 elif opt.guidance == 'clip':
     from nerf.clip import CLIP
     guidance = CLIP(device)

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -13,8 +13,6 @@ print(f'[INFO] loading options..')
 parser = argparse.ArgumentParser()
 parser.add_argument('--text', default=None, help="text prompt")
 parser.add_argument('--negative', default='', type=str, help="negative text prompt")
-# parser.add_argument('-O', action='store_true', help="equals --fp16 --cuda_ray --dir_text")
-# parser.add_argument('-O2', action='store_true', help="equals --fp16 --dir_text")
 parser.add_argument('--test', action='store_true', help="test mode")
 parser.add_argument('--eval_interval', type=int, default=10, help="evaluate on the valid set every interval epochs")
 parser.add_argument('--workspace', type=str, default='trial_gradio')
@@ -44,7 +42,7 @@ parser.add_argument('--density_thresh', type=float, default=10, help="threshold 
 parser.add_argument('--blob_density', type=float, default=10, help="max (center) density for the density blob")
 parser.add_argument('--blob_radius', type=float, default=0.3, help="control the radius for the density blob")
 # network backbone
-parser.add_argument('--fp16', action='store_true', help="use amp mixed precision training")
+parser.add_argument('--vram_O', action='store_true', help="optimization for low VRAM usage")
 parser.add_argument('--backbone', type=str, default='grid', help="nerf backbone, choose from [grid, vanilla]")
 parser.add_argument('--optim', type=str, default='adan', choices=['adan', 'adam', 'adamw'], help="optimizer")
 parser.add_argument('--sd_version', type=str, default='2.1', choices=['1.5', '2.0', '2.1'], help="stable diffusion version")
@@ -82,10 +80,10 @@ parser.add_argument('--max_spp', type=int, default=1, help="GUI rendering max sa
 
 parser.add_argument('--need_share', type=bool, default=False, help="do you want to share gradio app to external network?")
 
-opt = parser.parse_args() 
+opt = parser.parse_args()
 
 # default to use -O !!!
-opt.fp16 = True
+opt.vram_O = True
 opt.dir_text = True
 opt.cuda_ray = True
 # opt.lambda_entropy = 1e-4
@@ -162,7 +160,7 @@ with gr.Blocks(css=".gradio-container {max-width: 512px; margin: auto;}") as dem
 
         # simply reload everything...
         model = NeRFNetwork(opt)
-        
+
         if opt.optim == 'adan':
             from optimizer import Adan
             # Adan usually requires a larger LR
@@ -174,7 +172,7 @@ with gr.Blocks(css=".gradio-container {max-width: 512px; margin: auto;}") as dem
 
         scheduler = lambda optimizer: optim.lr_scheduler.LambdaLR(optimizer, lambda iter: 1) # fixed
 
-        trainer = Trainer('df', opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=0.95, fp16=opt.fp16, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
+        trainer = Trainer('df', opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=0.95, fp16=opt.vram_O, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
 
         # train (every ep only contain 8 steps, so we can get some vis every ~10s)
         STEPS = 8
@@ -188,7 +186,7 @@ with gr.Blocks(css=".gradio-container {max-width: 512px; margin: auto;}") as dem
         for epoch in range(max_epochs):
 
             trainer.train_gui(train_loader, step=STEPS)
-            
+
             # manual test and get intermediate results
             try:
                 data = next(loader)
@@ -219,7 +217,7 @@ with gr.Blocks(css=".gradio-container {max-width: 512px; margin: auto;}") as dem
                 video: gr.update(visible=False),
                 logs: f"training iters: {epoch * STEPS} / {iters}, lr: {trainer.optimizer.param_groups[0]['lr']:.6f}",
             }
-        
+
 
         # test
         trainer.test(test_loader)
@@ -227,18 +225,18 @@ with gr.Blocks(css=".gradio-container {max-width: 512px; margin: auto;}") as dem
         results = glob.glob(os.path.join(opt.workspace, 'results', '*rgb*.mp4'))
         assert results is not None, "cannot retrieve results!"
         results.sort(key=lambda x: os.path.getmtime(x)) # sort by mtime
-        
+
         end_t = time.time()
-        
+
         yield {
             image: gr.update(visible=False),
             video: gr.update(value=results[-1], visible=True),
             logs: f"Generation Finished in {(end_t - start_t)/ 60:.4f} minutes!",
         }
 
-    
+
     button.click(
-        submit, 
+        submit,
         [prompt, iters, seed],
         [image, video, logs]
     )

--- a/main.py
+++ b/main.py
@@ -56,8 +56,8 @@ if __name__ == '__main__':
     parser.add_argument('--sd_version', type=str, default='2.1', choices=['1.5', '2.0', '2.1'], help="stable diffusion version")
     parser.add_argument('--hf_key', type=str, default=None, help="hugging face Stable diffusion model key")
     # try this if CUDA OOM
-    parser.add_argument('--memory_saving_sd_config', action='store_true', help="prioritize VRAM savings when configuring Stable Diffusion")
-    # rendering resolution in training, decrease this if CUDA still OOM even if --memory_saving_sd_config is enabled.
+    parser.add_argument('--vram_O', type=int, default=0, choices=[0, 1, 2], help="VRAM optimization level for configuring Stable Diffusion")
+    # rendering resolution in training, decrease this if CUDA still OOM even if --vram_O is 2.
     parser.add_argument('--w', type=int, default=64, help="render width for NeRF in training")
     parser.add_argument('--h', type=int, default=64, help="render height for NeRF in training")
     
@@ -90,7 +90,7 @@ if __name__ == '__main__':
 
     opt = parser.parse_args()
 
-    if opt.memory_saving_sd_config:
+    if opt.vram_O > 0:
         opt.fp16 = True
 
     if opt.O:
@@ -176,7 +176,7 @@ if __name__ == '__main__':
 
         if opt.guidance == 'stable-diffusion':
             from sd import StableDiffusion
-            guidance = StableDiffusion(device, opt.memory_saving_sd_config, opt.sd_version, opt.hf_key)
+            guidance = StableDiffusion(device, opt.vram_O, opt.sd_version, opt.hf_key)
         elif opt.guidance == 'clip':
             from nerf.clip import CLIP
             guidance = CLIP(device)

--- a/main.py
+++ b/main.py
@@ -55,7 +55,9 @@ if __name__ == '__main__':
     parser.add_argument('--optim', type=str, default='adan', choices=['adan', 'adam'], help="optimizer")
     parser.add_argument('--sd_version', type=str, default='2.1', choices=['1.5', '2.0', '2.1'], help="stable diffusion version")
     parser.add_argument('--hf_key', type=str, default=None, help="hugging face Stable diffusion model key")
-    # rendering resolution in training, decrease this if CUDA OOM.
+    # try this if CUDA OOM
+    parser.add_argument('--memory_saving_sd_config', action='store_true', help="prioritize VRAM savings when configuring Stable Diffusion")
+    # rendering resolution in training, decrease this if CUDA still OOM even if --memory_saving_sd_config is enabled.
     parser.add_argument('--w', type=int, default=64, help="render width for NeRF in training")
     parser.add_argument('--h', type=int, default=64, help="render height for NeRF in training")
     
@@ -87,6 +89,9 @@ if __name__ == '__main__':
     parser.add_argument('--max_spp', type=int, default=1, help="GUI rendering max sample per pixel")
 
     opt = parser.parse_args()
+
+    if opt.memory_saving_sd_config:
+        opt.fp16 = True
 
     if opt.O:
         opt.fp16 = True
@@ -171,7 +176,7 @@ if __name__ == '__main__':
 
         if opt.guidance == 'stable-diffusion':
             from sd import StableDiffusion
-            guidance = StableDiffusion(device, opt.sd_version, opt.hf_key)
+            guidance = StableDiffusion(device, opt.memory_saving_sd_config, opt.sd_version, opt.hf_key)
         elif opt.guidance == 'clip':
             from nerf.clip import CLIP
             guidance = CLIP(device)

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--text', default=None, help="text prompt")
     parser.add_argument('--negative', default='', type=str, help="negative text prompt")
-    parser.add_argument('-O', action='store_true', help="equals --fp16 --cuda_ray --dir_text")
+    parser.add_argument('-O', action='store_true', help="equals --vram_O --cuda_ray --dir_text")
     parser.add_argument('-O2', action='store_true', help="equals --backbone vanilla --dir_text")
     parser.add_argument('--test', action='store_true', help="test mode")
     parser.add_argument('--eval_interval', type=int, default=1, help="evaluate on the valid set every interval epochs")
@@ -50,17 +50,16 @@ if __name__ == '__main__':
     parser.add_argument('--blob_density', type=float, default=10, help="max (center) density for the density blob")
     parser.add_argument('--blob_radius', type=float, default=0.5, help="control the radius for the density blob")
     # network backbone
-    parser.add_argument('--fp16', action='store_true', help="use amp mixed precision training")
     parser.add_argument('--backbone', type=str, default='grid', choices=['grid', 'vanilla', 'grid_taichi'], help="nerf backbone")
     parser.add_argument('--optim', type=str, default='adan', choices=['adan', 'adam'], help="optimizer")
     parser.add_argument('--sd_version', type=str, default='2.1', choices=['1.5', '2.0', '2.1'], help="stable diffusion version")
     parser.add_argument('--hf_key', type=str, default=None, help="hugging face Stable diffusion model key")
     # try this if CUDA OOM
-    parser.add_argument('--vram_O', type=int, default=0, choices=[0, 1, 2], help="VRAM optimization level for configuring Stable Diffusion")
-    # rendering resolution in training, decrease this if CUDA still OOM even if --vram_O is 2.
+    parser.add_argument('--vram_O', action='store_true', help="optimization for low VRAM usage")
+    # rendering resolution in training, decrease this if CUDA still OOM even if --vram_O enabled.
     parser.add_argument('--w', type=int, default=64, help="render width for NeRF in training")
     parser.add_argument('--h', type=int, default=64, help="render height for NeRF in training")
-    
+
     ### dataset options
     parser.add_argument('--bound', type=float, default=1, help="assume the scene is bounded in box(-bound, bound)")
     parser.add_argument('--dt_gamma', type=float, default=0, help="dt_gamma (>=0) for adaptive ray marching. set to 0 to disable, >0 to accelerate rendering (but usually with worse quality)")
@@ -90,18 +89,15 @@ if __name__ == '__main__':
 
     opt = parser.parse_args()
 
-    if opt.vram_O > 0:
-        opt.fp16 = True
-
     if opt.O:
-        opt.fp16 = True
+        opt.vram_O = True
         opt.dir_text = True
         opt.cuda_ray = True
 
     elif opt.O2:
-        # only use fp16 if not evaluating normals (else lead to NaNs in training...)
+        # only use vram_O if not evaluating normals (else lead to NaNs in training...)
         if opt.albedo:
-            opt.fp16 = True
+            opt.vram_O = True
         opt.dir_text = True
         opt.backbone = 'vanilla'
 
@@ -138,23 +134,23 @@ if __name__ == '__main__':
     if opt.test:
         guidance = None # no need to load guidance model at test
 
-        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, fp16=opt.fp16, use_checkpoint=opt.ckpt)
+        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, fp16=opt.vram_O, use_checkpoint=opt.ckpt)
 
         if opt.gui:
             gui = NeRFGUI(opt, trainer)
             gui.render()
-        
+
         else:
             test_loader = NeRFDataset(opt, device=device, type='test', H=opt.H, W=opt.W, size=100).dataloader()
             trainer.test(test_loader)
-            
+
             if opt.save_mesh:
-                # a special loader for poisson mesh reconstruction, 
+                # a special loader for poisson mesh reconstruction,
                 # loader = NeRFDataset(opt, device=device, type='test', H=128, W=128, size=100).dataloader()
                 trainer.save_mesh()
-    
+
     else:
-        
+
         train_loader = NeRFDataset(opt, device=device, type='train', H=opt.h, W=opt.w, size=100).dataloader()
 
         if opt.optim == 'adan':
@@ -183,14 +179,14 @@ if __name__ == '__main__':
         else:
             raise NotImplementedError(f'--guidance {opt.guidance} is not implemented.')
 
-        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=None, fp16=opt.fp16, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
+        trainer = Trainer(' '.join(sys.argv), 'df', opt, model, guidance, device=device, workspace=opt.workspace, optimizer=optimizer, ema_decay=None, fp16=opt.vram_O, lr_scheduler=scheduler, use_checkpoint=opt.ckpt, eval_interval=opt.eval_interval, scheduler_update_every_step=True)
 
         if opt.gui:
             trainer.train_loader = train_loader # attach dataloader to trainer
 
             gui = NeRFGUI(opt, trainer)
             gui.render()
-        
+
         else:
             valid_loader = NeRFDataset(opt, device=device, type='val', H=opt.H, W=opt.W, size=5).dataloader()
 

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ pip install taichi
 
 ### Tested environments
 * Ubuntu 22 with torch 1.12 & CUDA 11.6 on a V100.
+* Ubuntu 22 with torch 1.14 & CUDA 11.7 on a 3070.
 
 
 # Usage
@@ -84,7 +85,7 @@ First time running will take some time to compile the CUDA extensions.
 # - worse surface quality
 
 ## train with text prompt (with the default settings)
-# `-O` equals `--cuda_ray --fp16 --dir_text`
+# `-O` equals `--cuda_ray --vram_O --dir_text`
 # `--cuda_ray` enables instant-ngp-like occupancy grid based acceleration.
 # `--vram_O` enables various vram saving measures. Details [here](https://huggingface.co/docs/diffusers/optimization/fp16).
 # `--dir_text` enables view-dependent prompting.

--- a/readme.md
+++ b/readme.md
@@ -90,11 +90,15 @@ First time running will take some time to compile the CUDA extensions.
 # `--dir_text` enables view-dependent prompting.
 python main.py --text "a hamburger" --workspace trial -O
 
-# If the above gives you CUDA out of memory errors, try the memory saving config.
+# If the above gives you CUDA out of memory errors, try vram optimization level 1.
 # It makes torch use float16 precision for weights, which might trade away some output quality.
 # It also enables attention slicing which might trade away some execution speed.
 # Tested to run fine on 8GB VRAM (Nvidia 3070 Ti).
-python main.py --text "a hamburger" --workspace trial -O --memory_saving_sd_config
+python main.py --text "a hamburger" --workspace trial -O --vram_O 1
+# To further trade away time for more vram, try vram optimization level 2
+# Might allow larger --w and --h, which gives slower but higher quality results.
+# Tested to run fine on 8GB VRAM (Nvidia 3070 Ti).
+python main.py --text "a hamburger" --workspace trial -O --vram_O 1 --w 128 --h 128
 # use CUDA-free Taichi backend with `--backbone grid_taichi`
 python3 main.py --text "a hamburger" --workspace trial -O --backbone grid_taichi
 

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,11 @@ First time running will take some time to compile the CUDA extensions.
 # `--dir_text` enables view-dependent prompting.
 python main.py --text "a hamburger" --workspace trial -O
 
+# If the above gives you CUDA out of memory errors, try the memory saving config.
+# It makes torch use float16 precision for weights, which might trade away some output quality.
+# It also enables attention slicing which might trade away some execution speed.
+# Tested to run fine on 8GB VRAM (Nvidia 3070 Ti).
+python main.py --text "a hamburger" --workspace trial -O --memory_saving_sd_config
 # use CUDA-free Taichi backend with `--backbone grid_taichi`
 python3 main.py --text "a hamburger" --workspace trial -O --backbone grid_taichi
 

--- a/readme.md
+++ b/readme.md
@@ -10,17 +10,17 @@ The original paper's project page: [_DreamFusion: Text-to-3D using 2D Diffusion_
 
 https://user-images.githubusercontent.com/25863658/215996308-9fd959f5-b5c7-4a8e-a241-0fe63ec86a4a.mp4
 
-Colab notebooks: 
+Colab notebooks:
 * Instant-NGP backbone (`-O`): [![Instant-NGP Backbone](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1MXT3yfOFvO0ooKEfiUUvTKwUkrrlCHpF?usp=sharing)
 
-* Vanilla NeRF backbone (`-O2`): [![Vanilla Backbone](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1mvfxG-S_n_gZafWoattku7rLJ2kPoImL?usp=sharing) 
+* Vanilla NeRF backbone (`-O2`): [![Vanilla Backbone](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1mvfxG-S_n_gZafWoattku7rLJ2kPoImL?usp=sharing)
 
 https://user-images.githubusercontent.com/25863658/194241493-f3e68f78-aefe-479e-a4a8-001424a61b37.mp4
 
 ### [Gallery](https://github.com/ashawkey/stable-dreamfusion/issues/1) | [Update Logs](assets/update_logs.md)
 
 # Important Notice
-This project is a **work-in-progress**, and contains lots of differences from the paper. Also, many features are still not implemented now. **The current generation quality cannot match the results from the original paper, and many prompts still fail badly!** 
+This project is a **work-in-progress**, and contains lots of differences from the paper. Also, many features are still not implemented now. **The current generation quality cannot match the results from the original paper, and many prompts still fail badly!**
 
 ## Notable differences from the paper
 * Since the Imagen model is not publicly available, we use [Stable Diffusion](https://github.com/CompVis/stable-diffusion) to replace it (implementation from [diffusers](https://github.com/huggingface/diffusers)). Different from Imagen, Stable-Diffusion is a latent diffusion model, which diffuses in a latent space instead of the original image space. Therefore, we need the loss to propagate back from the VAE's encoder part too, which introduces extra time cost in training. Currently, 10000 training steps take about 3 hours to train on a V100.
@@ -61,7 +61,7 @@ pip install ./raymarching # install to python path (you still need the raymarchi
 ```
 
 ### Taichi backend (optional)
-Use [Taichi](https://github.com/taichi-dev/taichi) backend for Instant-NGP. It achieves comparable performance to CUDA implementation while **No CUDA** build is required. Install Taichi with pip: 
+Use [Taichi](https://github.com/taichi-dev/taichi) backend for Instant-NGP. It achieves comparable performance to CUDA implementation while **No CUDA** build is required. Install Taichi with pip:
 ```bash
 pip install taichi
 ```
@@ -77,7 +77,7 @@ First time running will take some time to compile the CUDA extensions.
 ```bash
 #### stable-dreamfusion setting
 
-### Instant-NGP NeRF Backbone 
+### Instant-NGP NeRF Backbone
 # + faster rendering speed
 # + less GPU memory (~16G)
 # - need to build CUDA extensions (a CUDA-free Taichi backend is available)
@@ -146,7 +146,7 @@ python main.py --workspace trial2 -O2 --test --gui # not recommended, FPS will b
 
 # Code organization & Advanced tips
 
-This is a simple description of the most important implementation details. 
+This is a simple description of the most important implementation details.
 If you are interested in improving this repo, this might be a starting point.
 Any contribution would be greatly appreciated!
 
@@ -198,6 +198,7 @@ return loss # functional loss
 
 Torch lets us trade away some vram for some ~30% speed gains if we step through a process called tracing first.
 If you'd like to try here's how:
+
  1. In `sd.py` you'll find these three lines commented out:
  ```python
             #torch.save(latent_model_input, "train_latent_model_input.pt")
@@ -209,14 +210,16 @@ If you'd like to try here's how:
  python main.py --text "a hamburger" --workspace trial -O --w 200 --h 200
  ```
  You only need to let it run for a few seconds, until you've confirmed that three `.pt` files have been created.
+
  2. Run the tracer script, which creates a `unet_traced.pt` file for you:
  ```bash
  python trace.py
  ```
+
  3. Comment out the three `torch.save` lines in `sd.py` again, and (re)-start another standard run. This time you should see a siginificant speed-up and maybe a bit
     higher vram usage than before.
 
-The tracing functionality has only been tested in combination with the `-O` option. Using it without `--vram_O` will require some changes inside `trace.py`.
+The tracing functionality has only been tested in combination with the `-O` option. Using it without `--vram_O` would probably require some changes inside `trace.py`.
 
 
 # Acknowledgement
@@ -231,11 +234,11 @@ The tracing functionality has only been tested in combination with the `-O` opti
     }
     ```
 
-* Huge thanks to the [Stable Diffusion](https://github.com/CompVis/stable-diffusion) and the [diffusers](https://github.com/huggingface/diffusers) library. 
+* Huge thanks to the [Stable Diffusion](https://github.com/CompVis/stable-diffusion) and the [diffusers](https://github.com/huggingface/diffusers) library.
 
     ```
     @misc{rombach2021highresolution,
-        title={High-Resolution Image Synthesis with Latent Diffusion Models}, 
+        title={High-Resolution Image Synthesis with Latent Diffusion Models},
         author={Robin Rombach and Andreas Blattmann and Dominik Lorenz and Patrick Esser and Björn Ommer},
         year={2021},
         eprint={2112.10752},

--- a/sd.py
+++ b/sd.py
@@ -1,5 +1,5 @@
 from transformers import CLIPTextModel, CLIPTokenizer, logging
-from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler, DDIMScheduler
+from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler, DDIMScheduler, StableDiffusionPipeline
 from diffusers.utils.import_utils import is_xformers_available
 
 # suppress partial model loading warning
@@ -33,7 +33,7 @@ def seed_everything(seed):
     #torch.backends.cudnn.benchmark = True
 
 class StableDiffusion(nn.Module):
-    def __init__(self, device, memory_saving_sd_config, sd_version='2.1', hf_key=None):
+    def __init__(self, device, vram_O, sd_version='2.1', hf_key=None):
         super().__init__()
 
         self.device = device
@@ -54,23 +54,25 @@ class StableDiffusion(nn.Module):
             raise ValueError(f'Stable-diffusion version {self.sd_version} not supported.')
 
         # Create model
-        if memory_saving_sd_config:
-            self.vae = AutoencoderKL.from_pretrained(model_key, subfolder="vae", torch_dtype=torch.float16).to(self.device)
-            self.tokenizer = CLIPTokenizer.from_pretrained(model_key, subfolder="tokenizer", torch_dtype=torch.float16)
-            self.text_encoder = CLIPTextModel.from_pretrained(model_key, subfolder="text_encoder", torch_dtype=torch.float16).to(self.device)
-            self.unet = UNet2DConditionModel.from_pretrained(model_key, subfolder="unet", torch_dtype=torch.float16).to(self.device)
-            self.unet.set_attention_slice("auto")
+        if vram_O > 0:
+            pipe = StableDiffusionPipeline.from_pretrained(model_key, torch_dtype=torch.float16)
+            if vram_O > 1:
+                pipe.enable_sequential_cpu_offload()
+            pipe.enable_attention_slicing(1)
+            self.vae = pipe.vae
+            self.tokenizer = pipe.tokenizer
+            self.text_encoder = pipe.text_encoder
+            self.unet = pipe.unet
+            self.scheduler = DDIMScheduler.from_pretrained(model_key, subfolder="scheduler", torch_dtype=torch.float16)
         else:
             self.vae = AutoencoderKL.from_pretrained(model_key, subfolder="vae").to(self.device)
             self.tokenizer = CLIPTokenizer.from_pretrained(model_key, subfolder="tokenizer")
             self.text_encoder = CLIPTextModel.from_pretrained(model_key, subfolder="text_encoder").to(self.device)
             self.unet = UNet2DConditionModel.from_pretrained(model_key, subfolder="unet").to(self.device)
+            self.scheduler = DDIMScheduler.from_pretrained(model_key, subfolder="scheduler")
 
         if is_xformers_available():
             self.unet.enable_xformers_memory_efficient_attention()
-        
-        self.scheduler = DDIMScheduler.from_pretrained(model_key, subfolder="scheduler")
-        # self.scheduler = PNDMScheduler.from_pretrained(model_key, subfolder="scheduler")
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
         self.min_step = int(self.num_train_timesteps * 0.02)
@@ -218,7 +220,7 @@ if __name__ == '__main__':
     parser.add_argument('--negative', default='', type=str)
     parser.add_argument('--sd_version', type=str, default='2.1', choices=['1.5', '2.0', '2.1'], help="stable diffusion version")
     parser.add_argument('--hf_key', type=str, default=None, help="hugging face Stable diffusion model key")
-    parser.add_argument('--memory_saving_sd_config', action='store_true', help="prioritize VRAM savings when configuring Stable Diffusion")
+    parser.add_argument('--vram_O', type=int, default=0, choices=[0, 1, 2], help="VRAM optimization level for configuring Stable Diffusion")
     parser.add_argument('-H', type=int, default=512)
     parser.add_argument('-W', type=int, default=512)
     parser.add_argument('--seed', type=int, default=0)
@@ -229,7 +231,7 @@ if __name__ == '__main__':
 
     device = torch.device('cuda')
 
-    sd = StableDiffusion(device, opt.memory_saving_sd_config, opt.sd_version, opt.hf_key)
+    sd = StableDiffusion(device, opt.vram_O, opt.sd_version, opt.hf_key)
 
     imgs = sd.prompt_to_img(opt.prompt, opt.negative, opt.H, opt.W, opt.steps)
 

--- a/trace.py
+++ b/trace.py
@@ -16,16 +16,15 @@ unet_runs_per_experiment = 50
 pipe = StableDiffusionPipeline.from_pretrained(
     "stabilityai/stable-diffusion-2-1-base",
     torch_dtype=torch.float16
-).to("cuda")
-# pipe.enable_sequential_cpu_offload()
-# pipe.enable_vae_slicing()
-# del pipe.vae.decoder
-# pipe.enable_attention_slicing(1)
-# if is_xformers_available():
-#     pipe.enable_xformers_memory_efficient_attention()
+)#.to("cuda")
+pipe.enable_sequential_cpu_offload()
+pipe.enable_vae_slicing()
+pipe.unet.to(memory_format=torch.channels_last)
+pipe.enable_attention_slicing(1)
+#if is_xformers_available(): # xformers seem to use more vram...
+#    pipe.enable_xformers_memory_efficient_attention()
 unet = pipe.unet
 unet.eval()
-unet.to(memory_format=torch.channels_last)  # use channels_last memory format
 unet.forward = functools.partial(unet.forward, return_dict=False)  # set return_dict=False as default
 
 # load inputs

--- a/trace.py
+++ b/trace.py
@@ -1,0 +1,76 @@
+import time
+import torch
+from diffusers import StableDiffusionPipeline
+from diffusers.utils.import_utils import is_xformers_available
+import functools
+
+# torch disable grad
+torch.set_grad_enabled(False)
+
+# set variables
+n_experiments = 2
+unet_runs_per_experiment = 50
+
+
+
+pipe = StableDiffusionPipeline.from_pretrained(
+    "stabilityai/stable-diffusion-2-1-base",
+    torch_dtype=torch.float16
+).to("cuda")
+# pipe.enable_sequential_cpu_offload()
+# pipe.enable_vae_slicing()
+# del pipe.vae.decoder
+# pipe.enable_attention_slicing(1)
+# if is_xformers_available():
+#     pipe.enable_xformers_memory_efficient_attention()
+unet = pipe.unet
+unet.eval()
+unet.to(memory_format=torch.channels_last)  # use channels_last memory format
+unet.forward = functools.partial(unet.forward, return_dict=False)  # set return_dict=False as default
+
+# load inputs
+train_latent_model_input = torch.load("train_latent_model_input.pt").to(torch.float16)
+train_t = torch.load("train_t.pt").to(torch.float16)
+train_text_embeddings = torch.load("train_text_embeddings.pt").to(torch.float16)
+
+# warmup
+for _ in range(3):
+    with torch.inference_mode():
+        inputs = (train_latent_model_input, train_t, train_text_embeddings)
+        orig_output = unet(*inputs)
+
+
+# trace
+print("tracing..")
+unet_traced = torch.jit.trace(unet, inputs)
+unet_traced.eval()
+print("done tracing")
+
+
+# warmup and optimize graph
+for _ in range(5):
+    with torch.inference_mode():
+        # Should have been the produce_latents inputs, but I can't seem to get a hold of them
+        inputs = (train_latent_model_input, train_t, train_text_embeddings)
+        orig_output = unet_traced(*inputs)
+
+
+# benchmarking
+with torch.inference_mode():
+    for _ in range(n_experiments):
+        torch.cuda.synchronize()
+        start_time = time.time()
+        for _ in range(unet_runs_per_experiment):
+            orig_output = unet_traced(*inputs)
+        torch.cuda.synchronize()
+        print(f"unet traced inference took {time.time() - start_time:.2f} seconds")
+    for _ in range(n_experiments):
+        torch.cuda.synchronize()
+        start_time = time.time()
+        for _ in range(unet_runs_per_experiment):
+            orig_output = unet(*inputs)
+        torch.cuda.synchronize()
+        print(f"unet inference took {time.time() - start_time:.2f} seconds")
+
+# save the model
+unet_traced.save("unet_traced.pt")


### PR DESCRIPTION
### PR is related to a problem

Yes, I wanted to run on 8 GB GPU (a 3070), but couldn't do it without some adjustments.

Enabling the provided memory saving sd config solves CUDA out of memory on my particular hardware setup.

The config's changes and their trade-offs:
  - Loads the model weights directly in half precision (16f instead of 32f). This might reduce output quality, not sure.
  - Enables attention slicing. This slows down inference times by about 10%.

### Alternatives I've considered

I looked up huggingface docs for memory savnig config alternatives.
https://huggingface.co/docs/diffusers/v0.14.0/en/optimization/fp16

To be honest I just implemented each optimization suggestion from the top and downwards until it worked.

After adding `self.unet.set_attention_slice("auto"), I got total GPU memory usage of 7132MiB, which was low enough for my GPU. That number was gotten from a test run like this:

```bash
$ python main.py --text "a hamburger" --workspace trial -O --memory_saving_sd_config
```

This works as expected and creates a hamburger in ~39 minutes.
