### PR TITLE
[taichi] Fix module name and background frequency encoder

### DIFF
--- a/encoding.py
+++ b/encoding.py
@@ -70,8 +70,8 @@ def get_encoder(encoding, input_dim=3,
         encoder = GridEncoder(input_dim=input_dim, num_levels=num_levels, level_dim=level_dim, base_resolution=base_resolution, log2_hashmap_size=log2_hashmap_size, desired_resolution=desired_resolution, gridtype='tiled', align_corners=align_corners, interpolation=interpolation)
     
     elif encoding == 'hashgrid_taichi':
-        from taichi_modules.hash_encoder import HashEncoder
-        encoder = HashEncoder(batch_size=4096) #TODO: hard encoded batch size
+        from taichi_modules.hash_encoder import HashEncoderTaichi
+        encoder = HashEncoderTaichi(batch_size=4096) #TODO: hard encoded batch size
 
     else:
         raise NotImplementedError('Unknown encoding mode, choose from [None, frequency, sphere_harmonics, hashgrid, tiledgrid]')

--- a/nerf/network_grid_taichi.py
+++ b/nerf/network_grid_taichi.py
@@ -46,8 +46,6 @@ class NeRFNetwork(NeRFRenderer):
         self.num_layers = num_layers
         self.hidden_dim = hidden_dim
 
-        # print("get the hashgrid taichi encoder")
-
         self.encoder, self.in_dim = get_encoder('hashgrid_taichi', input_dim=3, log2_hashmap_size=19, desired_resolution=2048 * self.bound, interpolation='smoothstep')
 
         self.sigma_net = MLP(self.in_dim, 4, hidden_dim, num_layers, bias=True)
@@ -57,11 +55,10 @@ class NeRFNetwork(NeRFRenderer):
 
         # background network
         if self.bg_radius > 0:
-            self.num_layers_bg = num_layers_bg   
+            self.num_layers_bg = num_layers_bg
             self.hidden_dim_bg = hidden_dim_bg
-            
             # use a very simple network to avoid it learning the prompt...
-            self.encoder_bg, self.in_dim_bg = get_encoder('frequency', input_dim=3, multires=4)
+            self.encoder_bg, self.in_dim_bg = get_encoder('frequency_torch', input_dim=3, multires=4) # TODO: freq encoder can be replaced by a Taichi implementation
             self.bg_net = MLP(self.in_dim_bg, 3, hidden_dim_bg, num_layers_bg, bias=True)
             
         else:

--- a/nerf/renderer.py
+++ b/nerf/renderer.py
@@ -127,8 +127,8 @@ class NeRFRenderer(nn.Module):
         
         if self.taichi_ray:
             from einops import rearrange
-            from taichi_modules import RayMarcher as RayMarcherTaichi
-            from taichi_modules import VolumeRenderer as VolumeRendererTaichi
+            from taichi_modules import RayMarcherTaichi
+            from taichi_modules import VolumeRendererTaichi
             from taichi_modules import RayAABBIntersector as RayAABBIntersectorTaichi
             from taichi_modules import raymarching_test as raymarching_test_taichi
             from taichi_modules import composite_test as composite_test_fw

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ pip install ./raymarching # install to python path (you still need the raymarchi
 ### Taichi backend (optional)
 Use [Taichi](https://github.com/taichi-dev/taichi) backend for Instant-NGP. It achieves comparable performance to CUDA implementation while **No CUDA** build is required. Install Taichi with pip: 
 ```bash
-pip install taichi
+pip install -i https://pypi.taichi.graphics/simple/ taichi-nightly
 ```
 
 ### Tested environments

--- a/taichi_modules/__init__.py
+++ b/taichi_modules/__init__.py
@@ -1,5 +1,5 @@
-from .ray_march import RayMarcher, raymarching_test
-from .volume_train import VolumeRenderer
+from .ray_march import RayMarcherTaichi, raymarching_test
+from .volume_train import VolumeRendererTaichi
 from .intersection import RayAABBIntersector
 from .volume_render_test import composite_test
 from .utils import packbits

--- a/taichi_modules/hash_encoder.py
+++ b/taichi_modules/hash_encoder.py
@@ -163,14 +163,14 @@ def hash_encode_kernel_half2(
         xyzs_embedding[i, level] = local_feature
 
 
-class HashEncoder(torch.nn.Module):
+class HashEncoderTaichi(torch.nn.Module):
 
     def __init__(self,
                  b=1.3195079565048218,
                  batch_size=8192,
                  data_type=data_type,
                  half2_opt=False):
-        super(HashEncoder, self).__init__()
+        super(HashEncoderTaichi, self).__init__()
 
         self.per_level_scale = b
         if batch_size < 2048:

--- a/taichi_modules/ray_march.py
+++ b/taichi_modules/ray_march.py
@@ -142,10 +142,10 @@ def raymarching_train_backword(segments: ti.types.ndarray(ndim=2),
         dL_drays_d[s] = dxyz * ts[index] + ddir
 
 
-class RayMarcher(torch.nn.Module):
+class RayMarcherTaichi(torch.nn.Module):
 
     def __init__(self, batch_size=8192):
-        super(RayMarcher, self).__init__()
+        super(RayMarcherTaichi, self).__init__()
 
         self.register_buffer('rays_a',
                              torch.zeros(batch_size, 3, dtype=torch.int32))

--- a/taichi_modules/volume_train.py
+++ b/taichi_modules/volume_train.py
@@ -109,10 +109,10 @@ def check_value(
             checker[I] = 1
 
 
-class VolumeRenderer(torch.nn.Module):
+class VolumeRendererTaichi(torch.nn.Module):
 
     def __init__(self, batch_size=8192, data_type=data_type):
-        super(VolumeRenderer, self).__init__()
+        super(VolumeRendererTaichi, self).__init__()
         # samples level
         self.sigmas_fields = ti.field(dtype=data_type,
                                       shape=(batch_size * 1024, ),


### PR DESCRIPTION
Related issue: #173 
- Fix module name for easy checking when printing network
- Recommend to install taichi nightly for half2 vectorization acceleration 
- Use torch frequency encoder for background network