### PR TITLE
Removes xformers from --vram_O use case

### DIFF
--- a/sd.py
+++ b/sd.py
@@ -79,9 +79,6 @@ class StableDiffusion(nn.Module):
                     return UNet2DConditionOutput(sample=sample)
             pipe.unet = TracedUNet()
 
-        if is_xformers_available():
-            pipe.enable_xformers_memory_efficient_attention()
-
         if vram_O:
             pipe.enable_sequential_cpu_offload()
             pipe.enable_vae_slicing()
@@ -89,8 +86,10 @@ class StableDiffusion(nn.Module):
             pipe.enable_attention_slicing(1)
             # pipe.enable_model_cpu_offload()
         else:
+            if is_xformers_available():
+                pipe.enable_xformers_memory_efficient_attention()
             pipe.to(device)
-        
+
         self.vae = pipe.vae
         self.tokenizer = pipe.tokenizer
         self.text_encoder = pipe.text_encoder


### PR DESCRIPTION
Details here: https://github.com/ashawkey/stable-dreamfusion/pull/174#issuecomment-1480970754

Note that my test were run on only one particular hw setup, so it might be useful to keep this PR open until we have confirmed that other hw setups behave similarly.

I don't know the reason why xformers seem to cause this significant slowdown with no added benefit on my machine.

Anyways, since the readme and install dependencies don't mention that xformers need to be installed separately, most people will likely run sd without xformers anyways.

Here's what I did to install xformers on my machine (Ubuntu 22.04):
```
pip install xformers
pip install triton
```