### PR TITLE
Fix C++ version on linux to C++17

### DIFF
--- a/freqencoder/setup.py
+++ b/freqencoder/setup.py
@@ -11,7 +11,7 @@ nvcc_flags = [
 ]
 
 if os.name == "posix":
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/gridencoder/setup.py
+++ b/gridencoder/setup.py
@@ -10,7 +10,7 @@ nvcc_flags = [
 ]
 
 if os.name == "posix":
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/raymarching/setup.py
+++ b/raymarching/setup.py
@@ -10,7 +10,7 @@ nvcc_flags = [
 ]
 
 if os.name == "posix":
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/shencoder/setup.py
+++ b/shencoder/setup.py
@@ -10,7 +10,7 @@ nvcc_flags = [
 ]
 
 if os.name == "posix":
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 


### PR DESCRIPTION
On Linux, errors get thrown because of an invalid C++ version when compiling freqencoder, shencoder, gridencoder, and raymarching.

```diff
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
```

This fix worked for me.